### PR TITLE
feat: auto-fetch Kubernetes credentials from cloud providers

### DIFF
--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -53,10 +53,27 @@ See [Azure Provider](../cloud/azure.md) for details.
 
 ```yaml
 kubernetes:
-  context: string           # kubectl context name
+  context: string           # kubectl context name (optional if using cloud auto-fetch)
   namespace: string         # Default namespace
   kubeconfig: string        # Path to kubeconfig file (optional)
+
+  # Auto-fetch credentials from cloud providers (mutually exclusive)
+  aks:                      # Azure Kubernetes Service
+    cluster: string         # AKS cluster name (required)
+    resource_group: string  # Azure resource group (required)
+
+  eks:                      # AWS Elastic Kubernetes Service
+    cluster: string         # EKS cluster name (required)
+    region: string          # AWS region (optional, falls back to aws.region)
+
+  gke:                      # Google Kubernetes Engine
+    cluster: string         # GKE cluster name (required)
+    zone: string            # Cluster zone (for zonal clusters)
+    region: string          # Cluster region (for regional clusters)
+    project: string         # GCP project (optional, falls back to gcp.project)
 ```
+
+When `aks`, `eks`, or `gke` is configured, ctx will automatically fetch credentials using the respective cloud CLI before switching kubectl context.
 
 ## Nomad
 
@@ -136,6 +153,9 @@ See [HashiCorp Vault](../secrets/vault.md) for details.
 bitwarden:
   auto_login: bool          # Auto-run 'bw login' if not authenticated
   sso: bool                 # Use SSO login
+  org_identifier: string    # Organization identifier for SSO login
+  server: string            # Self-hosted Bitwarden server URL
+  email: string             # Email for login (pre-fills prompt)
 ```
 
 ## 1Password

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -292,7 +292,11 @@ func ensureBitwardenUnlocked(cfg *types.BitwardenConfig, mgr *config.Manager, co
 
 		if useSSO {
 			yellow.Fprintf(os.Stderr, "  Bitwarden SSO login - opening browser...\n")
-			loginCmd = exec.Command("bw", "login", "--sso")
+			if cfg != nil && cfg.OrgIdentifier != "" {
+				loginCmd = exec.Command("bw", "login", "--sso", cfg.OrgIdentifier)
+			} else {
+				loginCmd = exec.Command("bw", "login", "--sso")
+			}
 		} else if email != "" {
 			yellow.Fprintf(os.Stderr, "  Bitwarden login (%s)...\n", email)
 			loginCmd = exec.Command("bw", "login", email)

--- a/internal/config/context_test.go
+++ b/internal/config/context_test.go
@@ -251,6 +251,130 @@ func TestValidateContext(t *testing.T) {
 			wantErr: true,
 			errMsg:  "SSH bastion must be configured",
 		},
+		{
+			name: "valid AKS config",
+			ctx: &types.ContextConfig{
+				Name: "test",
+				Kubernetes: &types.KubernetesConfig{
+					AKS: &types.AKSConfig{
+						Cluster:       "my-cluster",
+						ResourceGroup: "my-rg",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "AKS missing cluster",
+			ctx: &types.ContextConfig{
+				Name: "test",
+				Kubernetes: &types.KubernetesConfig{
+					AKS: &types.AKSConfig{
+						ResourceGroup: "my-rg",
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "kubernetes.aks.cluster is required",
+		},
+		{
+			name: "AKS missing resource group",
+			ctx: &types.ContextConfig{
+				Name: "test",
+				Kubernetes: &types.KubernetesConfig{
+					AKS: &types.AKSConfig{
+						Cluster: "my-cluster",
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "kubernetes.aks.resource_group is required",
+		},
+		{
+			name: "valid EKS config",
+			ctx: &types.ContextConfig{
+				Name: "test",
+				Kubernetes: &types.KubernetesConfig{
+					EKS: &types.EKSConfig{
+						Cluster: "my-cluster",
+						Region:  "us-east-1",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "EKS missing cluster",
+			ctx: &types.ContextConfig{
+				Name: "test",
+				Kubernetes: &types.KubernetesConfig{
+					EKS: &types.EKSConfig{
+						Region: "us-east-1",
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "kubernetes.eks.cluster is required",
+		},
+		{
+			name: "valid GKE config with zone",
+			ctx: &types.ContextConfig{
+				Name: "test",
+				Kubernetes: &types.KubernetesConfig{
+					GKE: &types.GKEConfig{
+						Cluster: "my-cluster",
+						Zone:    "us-central1-a",
+						Project: "my-project",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "GKE missing cluster",
+			ctx: &types.ContextConfig{
+				Name: "test",
+				Kubernetes: &types.KubernetesConfig{
+					GKE: &types.GKEConfig{
+						Zone:    "us-central1-a",
+						Project: "my-project",
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "kubernetes.gke.cluster is required",
+		},
+		{
+			name: "GKE missing zone and region",
+			ctx: &types.ContextConfig{
+				Name: "test",
+				Kubernetes: &types.KubernetesConfig{
+					GKE: &types.GKEConfig{
+						Cluster: "my-cluster",
+						Project: "my-project",
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "kubernetes.gke requires either zone or region",
+		},
+		{
+			name: "multiple cloud k8s providers",
+			ctx: &types.ContextConfig{
+				Name: "test",
+				Kubernetes: &types.KubernetesConfig{
+					AKS: &types.AKSConfig{
+						Cluster:       "aks-cluster",
+						ResourceGroup: "my-rg",
+					},
+					EKS: &types.EKSConfig{
+						Cluster: "eks-cluster",
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "only one of aks, eks, or gke",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -58,11 +58,34 @@ type AzureConfig struct {
 	AutoLogin      bool   `yaml:"auto_login,omitempty" mapstructure:"auto_login"`
 }
 
+// AKSConfig holds Azure Kubernetes Service configuration for auto-fetching credentials.
+type AKSConfig struct {
+	Cluster       string `yaml:"cluster" mapstructure:"cluster"`
+	ResourceGroup string `yaml:"resource_group" mapstructure:"resource_group"`
+}
+
+// EKSConfig holds AWS Elastic Kubernetes Service configuration for auto-fetching credentials.
+type EKSConfig struct {
+	Cluster string `yaml:"cluster" mapstructure:"cluster"`
+	Region  string `yaml:"region,omitempty" mapstructure:"region"` // Optional, falls back to aws.region
+}
+
+// GKEConfig holds Google Kubernetes Engine configuration for auto-fetching credentials.
+type GKEConfig struct {
+	Cluster string `yaml:"cluster" mapstructure:"cluster"`
+	Zone    string `yaml:"zone,omitempty" mapstructure:"zone"`       // Zonal cluster
+	Region  string `yaml:"region,omitempty" mapstructure:"region"`   // Regional cluster
+	Project string `yaml:"project,omitempty" mapstructure:"project"` // Optional, falls back to gcp.project
+}
+
 // KubernetesConfig holds Kubernetes-specific configuration.
 type KubernetesConfig struct {
-	Context    string `yaml:"context" mapstructure:"context"`
-	Namespace  string `yaml:"namespace" mapstructure:"namespace"`
-	Kubeconfig string `yaml:"kubeconfig" mapstructure:"kubeconfig"`
+	Context    string     `yaml:"context,omitempty" mapstructure:"context"`
+	Namespace  string     `yaml:"namespace,omitempty" mapstructure:"namespace"`
+	Kubeconfig string     `yaml:"kubeconfig,omitempty" mapstructure:"kubeconfig"`
+	AKS        *AKSConfig `yaml:"aks,omitempty" mapstructure:"aks"`
+	EKS        *EKSConfig `yaml:"eks,omitempty" mapstructure:"eks"`
+	GKE        *GKEConfig `yaml:"gke,omitempty" mapstructure:"gke"`
 }
 
 // NomadConfig holds Nomad-specific configuration.
@@ -163,10 +186,11 @@ type VaultConfig struct {
 
 // BitwardenConfig holds Bitwarden authentication configuration.
 type BitwardenConfig struct {
-	Server    string `yaml:"server,omitempty" mapstructure:"server"`         // Self-hosted Bitwarden server URL
-	Email     string `yaml:"email,omitempty" mapstructure:"email"`           // Email for login (pre-fills prompt)
-	AutoLogin bool   `yaml:"auto_login,omitempty" mapstructure:"auto_login"` // Auto-run 'bw login' if not authenticated
-	SSO       bool   `yaml:"sso,omitempty" mapstructure:"sso"`               // Use SSO login instead of email/password
+	Server        string `yaml:"server,omitempty" mapstructure:"server"`                 // Self-hosted Bitwarden server URL
+	Email         string `yaml:"email,omitempty" mapstructure:"email"`                   // Email for login (pre-fills prompt)
+	OrgIdentifier string `yaml:"org_identifier,omitempty" mapstructure:"org_identifier"` // Organization identifier for SSO login
+	AutoLogin     bool   `yaml:"auto_login,omitempty" mapstructure:"auto_login"`         // Auto-run 'bw login' if not authenticated
+	SSO           bool   `yaml:"sso,omitempty" mapstructure:"sso"`                       // Use SSO login instead of email/password
 }
 
 // OnePasswordConfig holds 1Password authentication configuration.


### PR DESCRIPTION
Add support for automatically fetching Kubernetes credentials when switching contexts:

- AKS: runs `az aks get-credentials` with cluster/resource_group config
- EKS: runs `aws eks update-kubeconfig` with cluster/region config
- GKE: runs `gcloud container clusters get-credentials` with cluster/zone/project

Additional improvements:

- OpenVPN: use DNS update scripts for proper DNS resolution
- Azure login: skip interactive subscription picker, suppress JSON output
- Bitwarden SSO: add org_identifier support for SSO login
- Validation: ensure only one cloud k8s provider is configured
- Tests: add validation tests for kubernetes cloud configs
- Docs: update configuration reference
