### PR TITLE
enhacement: Added addtioal cloud context config option so non-suporte…

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -34,7 +34,7 @@ Output columns:
 
 - `NAME` - Context name (abstract contexts prefixed with `~`)
 - `ENVIRONMENT` - Environment type
-- `CLOUD` - Configured cloud providers
+- `CLOUD` - Cloud providers (auto-detected from `aws`, `gcp`, `azure` configs + custom `cloud` label)
 - `ORCHESTRATION` - Configured orchestrators
 
 ### `ctx use <name>`

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -12,6 +12,7 @@ Complete reference for all context configuration options.
 | `extends` | string | Parent context name to inherit from |
 | `abstract` | bool | If true, context cannot be used directly |
 | `env_color` | string | Prompt color: `red`, `yellow`, `green`, `blue`, `cyan`, `magenta`, `white` |
+| `cloud` | string | Cloud provider label for platforms without native integration (e.g., `digitalocean`, `huawei`, `otc`). Shows in CLOUD column alongside auto-detected providers. Useful for identifying where your Kubernetes cluster is hosted when using non-major cloud providers. |
 | `tags` | []string | Tags for filtering and organization |
 
 ## AWS

--- a/internal/config/types_definitions.go
+++ b/internal/config/types_definitions.go
@@ -319,6 +319,7 @@ type ContextConfig struct {
 	Description string            `yaml:"description" mapstructure:"description"`
 	Environment Environment       `yaml:"environment" mapstructure:"environment"`
 	EnvColor    string            `yaml:"env_color,omitempty" mapstructure:"env_color"` // red, yellow, green, blue, cyan, magenta, white
+	Cloud       string            `yaml:"cloud,omitempty" mapstructure:"cloud"`         // Custom cloud provider label (e.g., digitalocean, huawei)
 	Tags        []string          `yaml:"tags" mapstructure:"tags"`
 	Tunnels     []TunnelConfig    `yaml:"tunnels,omitempty" mapstructure:"tunnels"`
 	// Databases
@@ -329,6 +330,11 @@ type ContextConfig struct {
 // GetCloudProviders returns a list of configured cloud providers.
 func (c *ContextConfig) GetCloudProviders() []string {
 	var providers []string
+	// Add custom cloud label first if set
+	if c.Cloud != "" {
+		providers = append(providers, c.Cloud)
+	}
+	// Auto-detect configured providers
 	if c.AWS != nil {
 		providers = append(providers, "aws")
 	}

--- a/internal/config/types_test_definitions.go
+++ b/internal/config/types_test_definitions.go
@@ -55,6 +55,31 @@ func TestContextConfig_GetCloudProviders(t *testing.T) {
 			ctx:  &ContextConfig{},
 			want: nil,
 		},
+		{
+			name: "custom cloud only",
+			ctx: &ContextConfig{
+				Cloud: "digitalocean",
+			},
+			want: []string{"digitalocean"},
+		},
+		{
+			name: "custom cloud with aws",
+			ctx: &ContextConfig{
+				Cloud: "digitalocean",
+				AWS:   &AWSConfig{Profile: "test"},
+			},
+			want: []string{"digitalocean", "aws"},
+		},
+		{
+			name: "custom cloud with all providers",
+			ctx: &ContextConfig{
+				Cloud: "huawei",
+				AWS:   &AWSConfig{Profile: "test"},
+				GCP:   &GCPConfig{Project: "test"},
+				Azure: &AzureConfig{SubscriptionID: "test"},
+			},
+			want: []string{"huawei", "aws", "gcp", "azure"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
…d cloud providers hosting k8s clusters can be shown in ctz list command under CLOUD column