### PR TITLE
feat(secrets): add secrets.files support for writing secrets to temp files

### DIFF
--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -180,7 +180,25 @@ secrets:
     ENV_VAR_NAME: "item-name"     # 1Password item name
   vault:
     ENV_VAR_NAME: "path#field"    # Vault path and field
+
+  # Secret files: fetch secret content, write to a secure temp file,
+  # export the file path as an env var. Cleaned up on deactivate.
+  files:
+    KUBECONFIG:                   # Env var that will hold the temp file path
+      onepassword: "My K8s Cluster/kubeconfig"
+    SSH_KEY:
+      bitwarden: "Deploy SSH Key#notes"
 ```
+
+### Secret Files
+
+The `secrets.files` section fetches secret content from any supported provider and writes it to a secure temporary file (`/dev/shm` on Linux, system temp directory on macOS). The env var is set to the file path, not the content itself.
+
+This is useful for kubeconfig files, SSH keys, TLS certificates, or anything that tools expect as a file path rather than an inline value. Files are created with `0600` permissions and securely deleted (zero-filled) on `ctx deactivate`.
+
+Each entry must specify exactly one provider: `bitwarden`, `onepassword`, `vault`, `aws_secrets_manager`, `aws_ssm`, or `gcp_secret_manager`.
+
+Secret file paths are added to `env:` after resolution, so they participate in variable interpolation. For example, `${KUBECONFIG}` in `kubernetes.kubeconfig` will resolve to the temp file path.
 
 See [Secrets Management](../secrets/index.md) for details.
 

--- a/examples/with-secrets.yaml
+++ b/examples/with-secrets.yaml
@@ -40,7 +40,18 @@ secrets:
   aws_ssm:
     FEATURE_FLAGS: "/prod/app/feature_flags"
 
+  # Secret files: fetched and written to secure temp files (/dev/shm on Linux).
+  # The env var is set to the temp file path, not the content.
+  # Files are securely deleted on 'ctx deactivate'.
+  files:
+    KUBECONFIG:
+      vault: "infrastructure/production#kubeconfig"
+    SSH_KEY:
+      bitwarden: "Deploy SSH Key#notes"
+
 kubernetes:
+  # ${KUBECONFIG} resolves to the temp file path from secrets.files above
+  kubeconfig: "${KUBECONFIG}"
   context: prod-cluster
   namespace: app
 

--- a/internal/cli/cloud.go
+++ b/internal/cli/cloud.go
@@ -479,7 +479,7 @@ func convertCloudContext(shared *cloud.SharedContext) (*config.ContextConfig, er
 	}
 
 	// Then convert JSON to YAML-compatible map
-	var configMap map[string]interface{}
+	var configMap map[string]any
 	if err := json.Unmarshal(configJSON, &configMap); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 	}

--- a/internal/cli/deactivate.go
+++ b/internal/cli/deactivate.go
@@ -183,6 +183,11 @@ func runDeactivate(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Clean up secret files
+	if err := mgr.CleanupSecretFiles(currentContext); err != nil {
+		yellow.Fprintf(os.Stderr, "⚠ Failed to clean up secret files: %v\n", err)
+	}
+
 	fmt.Fprintln(os.Stderr)
 	green.Fprintf(os.Stderr, "✓ Context '%s' deactivated.\n", currentContext)
 	fmt.Fprintln(os.Stderr)

--- a/internal/cli/logout.go
+++ b/internal/cli/logout.go
@@ -157,6 +157,11 @@ func runLogout(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// 9. Clean up secret files
+	if err := mgr.CleanupSecretFiles(contextName); err != nil {
+		yellow.Fprintf(os.Stderr, "⚠ Failed to clean up secret files: %v\n", err)
+	}
+
 	// If this was the current context, clear state files
 	if os.Getenv("CTX_CURRENT") == contextName {
 		if err := mgr.ClearCurrentContext(); err != nil {

--- a/internal/cli/secret_files.go
+++ b/internal/cli/secret_files.go
@@ -1,0 +1,237 @@
+// SPDX-FileCopyrightText: 2026 Vedran Lebo <vedran@flyingpenguin.tech>
+// SPDX-License-Identifier: MIT
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/fatih/color"
+	"github.com/vlebo/ctx/internal/config"
+)
+
+// SecretFilesResult holds the results of resolving secret files.
+type SecretFilesResult struct {
+	EnvVars   map[string]string     // ENV_VAR -> temp file path
+	State     *config.SecretFilesState
+	FileCount int
+}
+
+// resolveSecretFiles fetches secrets from providers and writes them to secure temp files.
+// Returns a map of ENV_VAR -> temp file path for each resolved secret file.
+func resolveSecretFiles(cfg *config.SecretsConfig, mgr *config.Manager, contextName string,
+	bitwardenCfg *config.BitwardenConfig, onePasswordCfg *config.OnePasswordConfig,
+	vaultCfg *config.VaultConfig, vaultToken string,
+	awsCfg *config.AWSConfig, awsCreds *config.AWSCredentials,
+	gcpCfg *config.GCPConfig, gcpConfigDir string,
+	browserCfg *config.BrowserConfig) (*SecretFilesResult, error) {
+
+	if cfg == nil || len(cfg.Files) == 0 {
+		return nil, nil
+	}
+
+	yellow := color.New(color.FgYellow)
+	green := color.New(color.FgGreen)
+
+	yellow.Fprintf(os.Stderr, "• Resolving secret files...\n")
+
+	tmpDir := getSecretTempDir()
+
+	result := &SecretFilesResult{
+		EnvVars: make(map[string]string),
+		State: &config.SecretFilesState{
+			ContextName: contextName,
+			CreatedAt:   time.Now(),
+			Files:       make(map[string]config.SecretFileEntry),
+		},
+	}
+
+	for envVar, src := range cfg.Files {
+		provider, itemSpec, err := getSecretFileProvider(src)
+		if err != nil {
+			return nil, fmt.Errorf("secret file %s: %w", envVar, err)
+		}
+
+		// Fetch the secret content using existing provider functions
+		var content string
+		switch provider {
+		case "bitwarden":
+			if err := checkBitwardenCLI(); err != nil {
+				return nil, err
+			}
+			if err := ensureBitwardenUnlocked(bitwardenCfg, mgr, contextName, browserCfg); err != nil {
+				return nil, err
+			}
+			content, err = getBitwardenSecret(itemSpec)
+		case "onepassword":
+			if err := checkOnePasswordCLI(); err != nil {
+				return nil, err
+			}
+			if err := ensureOnePasswordUnlocked(onePasswordCfg, mgr, contextName, browserCfg); err != nil {
+				return nil, err
+			}
+			content, err = getOnePasswordSecret(itemSpec)
+		case "vault":
+			if vaultCfg == nil {
+				return nil, fmt.Errorf("secrets.files.%s uses vault but no vault: section configured", envVar)
+			}
+			if err := checkVaultCLI(); err != nil {
+				return nil, err
+			}
+			content, err = getVaultSecret(vaultCfg, vaultToken, itemSpec)
+		case "aws_secrets_manager":
+			if err := checkAWSCLI(); err != nil {
+				return nil, err
+			}
+			content, err = getAWSSecretsManagerSecret(awsCfg, awsCreds, itemSpec)
+		case "aws_ssm":
+			if err := checkAWSCLI(); err != nil {
+				return nil, err
+			}
+			content, err = getAWSSSMParameter(awsCfg, awsCreds, itemSpec)
+		case "gcp_secret_manager":
+			if err := checkGCloudCLI(); err != nil {
+				return nil, err
+			}
+			content, err = getGCPSecret(gcpCfg, gcpConfigDir, itemSpec)
+		default:
+			return nil, fmt.Errorf("secret file %s: unknown provider %q", envVar, provider)
+		}
+
+		if err != nil {
+			return nil, fmt.Errorf("secret file %s (%s): %w", envVar, provider, err)
+		}
+
+		// Write content to a secure temp file
+		filePath, err := writeSecretFile(tmpDir, contextName, envVar, content)
+		if err != nil {
+			return nil, fmt.Errorf("secret file %s: failed to write temp file: %w", envVar, err)
+		}
+
+		result.EnvVars[envVar] = filePath
+		result.State.Files[envVar] = config.SecretFileEntry{
+			Path:      filePath,
+			EnvVar:    envVar,
+			Provider:  provider,
+			CreatedAt: time.Now(),
+		}
+		result.FileCount++
+	}
+
+	// Save state for cleanup on deactivate
+	if err := mgr.SaveSecretFilesState(result.State); err != nil {
+		yellow.Fprintf(os.Stderr, "⚠ Failed to save secret files state: %v\n", err)
+	}
+
+	green.Fprintf(os.Stderr, "✓ Wrote %d secret file(s) to %s\n", result.FileCount, tmpDir)
+
+	return result, nil
+}
+
+// getSecretTempDir returns a secure temporary directory for secret files.
+// Prefers /dev/shm (Linux tmpfs, never touches disk) when available.
+func getSecretTempDir() string {
+	if runtime.GOOS == "linux" {
+		if info, err := os.Stat("/dev/shm"); err == nil && info.IsDir() {
+			return "/dev/shm"
+		}
+	}
+	return os.TempDir()
+}
+
+// writeSecretFile writes secret content to a temp file with restrictive permissions.
+// Returns the path to the created file.
+func writeSecretFile(dir, contextName, envVar, content string) (string, error) {
+	pattern := fmt.Sprintf("ctx-%s-%s-*", contextName, envVar)
+	f, err := os.CreateTemp(dir, pattern)
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp file: %w", err)
+	}
+	defer f.Close()
+
+	// Set restrictive permissions before writing content
+	if err := f.Chmod(0o600); err != nil {
+		os.Remove(f.Name())
+		return "", fmt.Errorf("failed to set permissions: %w", err)
+	}
+
+	if _, err := f.WriteString(content); err != nil {
+		os.Remove(f.Name())
+		return "", fmt.Errorf("failed to write content: %w", err)
+	}
+
+	return f.Name(), nil
+}
+
+// secureDeleteFile zeros out a file's content before removing it.
+func secureDeleteFile(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // Already gone
+		}
+		return err
+	}
+
+	// Zero-fill
+	if size := info.Size(); size > 0 {
+		zeros := make([]byte, size)
+		if err := os.WriteFile(path, zeros, 0o600); err != nil {
+			// Best effort - still try to remove
+			os.Remove(path)
+			return err
+		}
+	}
+
+	return os.Remove(path)
+}
+
+// getSecretFileProvider determines which provider is configured in a SecretFileSource.
+// Returns the provider name, item spec, and an error if zero or more than one provider is set.
+func getSecretFileProvider(src config.SecretFileSource) (string, string, error) {
+	var provider, itemSpec string
+	count := 0
+
+	if src.Bitwarden != "" {
+		provider = "bitwarden"
+		itemSpec = src.Bitwarden
+		count++
+	}
+	if src.OnePassword != "" {
+		provider = "onepassword"
+		itemSpec = src.OnePassword
+		count++
+	}
+	if src.Vault != "" {
+		provider = "vault"
+		itemSpec = src.Vault
+		count++
+	}
+	if src.AWSSecretsManager != "" {
+		provider = "aws_secrets_manager"
+		itemSpec = src.AWSSecretsManager
+		count++
+	}
+	if src.AWSSSM != "" {
+		provider = "aws_ssm"
+		itemSpec = src.AWSSSM
+		count++
+	}
+	if src.GCPSecretManager != "" {
+		provider = "gcp_secret_manager"
+		itemSpec = src.GCPSecretManager
+		count++
+	}
+
+	if count == 0 {
+		return "", "", fmt.Errorf("no provider specified (set one of: bitwarden, onepassword, vault, aws_secrets_manager, aws_ssm, gcp_secret_manager)")
+	}
+	if count > 1 {
+		return "", "", fmt.Errorf("exactly one provider must be specified, found %d", count)
+	}
+
+	return provider, itemSpec, nil
+}

--- a/internal/cli/secret_files_test.go
+++ b/internal/cli/secret_files_test.go
@@ -1,0 +1,200 @@
+// SPDX-FileCopyrightText: 2026 Vedran Lebo <vedran@flyingpenguin.tech>
+// SPDX-License-Identifier: MIT
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/vlebo/ctx/internal/config"
+)
+
+func TestWriteSecretFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	path, err := writeSecretFile(tmpDir, "test-ctx", "KUBECONFIG", "apiVersion: v1\nkind: Config\n")
+	if err != nil {
+		t.Fatalf("writeSecretFile() error = %v", err)
+	}
+
+	// Verify file exists
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("File not found at %s: %v", path, err)
+	}
+
+	// Verify permissions are 0600
+	if runtime.GOOS != "windows" {
+		perm := info.Mode().Perm()
+		if perm != 0o600 {
+			t.Errorf("File permissions = %o, want 0600", perm)
+		}
+	}
+
+	// Verify content
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("Failed to read file: %v", err)
+	}
+	if string(content) != "apiVersion: v1\nkind: Config\n" {
+		t.Errorf("File content = %q, want kubeconfig yaml", string(content))
+	}
+
+	// Verify filename pattern
+	base := filepath.Base(path)
+	if len(base) == 0 {
+		t.Error("Empty filename")
+	}
+}
+
+func TestSecureDeleteFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a file with content
+	path := filepath.Join(tmpDir, "secret.txt")
+	if err := os.WriteFile(path, []byte("super-secret-content"), 0o600); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	// Securely delete it
+	if err := secureDeleteFile(path); err != nil {
+		t.Fatalf("secureDeleteFile() error = %v", err)
+	}
+
+	// Verify file is gone
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("File should not exist after secure delete")
+	}
+}
+
+func TestSecureDeleteFile_NonExistent(t *testing.T) {
+	// Should not error on non-existent file
+	err := secureDeleteFile("/tmp/does-not-exist-ctx-test-file")
+	if err != nil {
+		t.Errorf("secureDeleteFile() should not error on non-existent file, got: %v", err)
+	}
+}
+
+func TestGetSecretTempDir(t *testing.T) {
+	dir := getSecretTempDir()
+
+	if dir == "" {
+		t.Error("getSecretTempDir() returned empty string")
+	}
+
+	// Verify the directory exists
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("getSecretTempDir() returned non-existent dir: %v", err)
+	}
+	if !info.IsDir() {
+		t.Error("getSecretTempDir() returned a non-directory path")
+	}
+
+	// On Linux, should prefer /dev/shm
+	if runtime.GOOS == "linux" {
+		if _, err := os.Stat("/dev/shm"); err == nil {
+			if dir != "/dev/shm" {
+				t.Errorf("On Linux with /dev/shm available, expected /dev/shm, got %s", dir)
+			}
+		}
+	}
+}
+
+func TestGetSecretFileProvider(t *testing.T) {
+	tests := []struct {
+		name        string
+		src         config.SecretFileSource
+		wantProv    string
+		wantSpec    string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:     "bitwarden provider",
+			src:      config.SecretFileSource{Bitwarden: "My Item#notes"},
+			wantProv: "bitwarden",
+			wantSpec: "My Item#notes",
+		},
+		{
+			name:     "onepassword provider",
+			src:      config.SecretFileSource{OnePassword: "My K8s Cluster/kubeconfig"},
+			wantProv: "onepassword",
+			wantSpec: "My K8s Cluster/kubeconfig",
+		},
+		{
+			name:     "vault provider",
+			src:      config.SecretFileSource{Vault: "secret/data/k8s#kubeconfig"},
+			wantProv: "vault",
+			wantSpec: "secret/data/k8s#kubeconfig",
+		},
+		{
+			name:     "aws_secrets_manager provider",
+			src:      config.SecretFileSource{AWSSecretsManager: "my-kubeconfig"},
+			wantProv: "aws_secrets_manager",
+			wantSpec: "my-kubeconfig",
+		},
+		{
+			name:     "aws_ssm provider",
+			src:      config.SecretFileSource{AWSSSM: "/config/kubeconfig"},
+			wantProv: "aws_ssm",
+			wantSpec: "/config/kubeconfig",
+		},
+		{
+			name:     "gcp_secret_manager provider",
+			src:      config.SecretFileSource{GCPSecretManager: "kubeconfig-secret"},
+			wantProv: "gcp_secret_manager",
+			wantSpec: "kubeconfig-secret",
+		},
+		{
+			name:        "no provider",
+			src:         config.SecretFileSource{},
+			wantErr:     true,
+			errContains: "no provider specified",
+		},
+		{
+			name:        "multiple providers",
+			src:         config.SecretFileSource{Bitwarden: "item1", OnePassword: "item2"},
+			wantErr:     true,
+			errContains: "exactly one provider",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prov, spec, err := getSecretFileProvider(tt.src)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("Expected error, got nil")
+				}
+				if tt.errContains != "" && !containsStr(err.Error(), tt.errContains) {
+					t.Errorf("Error %q should contain %q", err.Error(), tt.errContains)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if prov != tt.wantProv {
+				t.Errorf("provider = %q, want %q", prov, tt.wantProv)
+			}
+			if spec != tt.wantSpec {
+				t.Errorf("itemSpec = %q, want %q", spec, tt.wantSpec)
+			}
+		})
+	}
+}
+
+func containsStr(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/tunnel.go
+++ b/internal/cli/tunnel.go
@@ -815,7 +815,7 @@ func sendTunnelEvent(mgr *config.Manager, contextName, environment, action strin
 		return
 	}
 
-	details := map[string]interface{}{
+	details := map[string]any{
 		"tunnels": tunnelNames,
 	}
 

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -38,12 +38,12 @@ func (c *Client) IsConfigured() bool {
 
 // AuditEvent represents an audit event to send to the cloud server.
 type AuditEvent struct {
-	Action       string                 `json:"action"`
-	ContextName  string                 `json:"context_name,omitempty"`
-	Environment  string                 `json:"environment,omitempty"`
-	Details      map[string]interface{} `json:"details,omitempty"`
-	Success      bool                   `json:"success"`
-	ErrorMessage string                 `json:"error_message,omitempty"`
+	Action       string         `json:"action"`
+	ContextName  string         `json:"context_name,omitempty"`
+	Environment  string         `json:"environment,omitempty"`
+	Details      map[string]any `json:"details,omitempty"`
+	Success      bool           `json:"success"`
+	ErrorMessage string         `json:"error_message,omitempty"`
 }
 
 // HeartbeatInput represents heartbeat data to send to the cloud server.
@@ -56,15 +56,15 @@ type HeartbeatInput struct {
 
 // SharedContext represents a context fetched from the cloud server.
 type SharedContext struct {
-	ID          string                 `json:"id"`
-	Name        string                 `json:"name"`
-	Description string                 `json:"description,omitempty"`
-	Environment string                 `json:"environment,omitempty"`
-	Config      map[string]interface{} `json:"config"`
-	Version     int                    `json:"version"`
-	IsAbstract  bool                   `json:"is_abstract"`
-	Extends     string                 `json:"extends,omitempty"`
-	UpdatedAt   string                 `json:"updated_at"`
+	ID          string         `json:"id"`
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	Environment string         `json:"environment,omitempty"`
+	Config      map[string]any `json:"config"`
+	Version     int            `json:"version"`
+	IsAbstract  bool           `json:"is_abstract"`
+	Extends     string         `json:"extends,omitempty"`
+	UpdatedAt   string         `json:"updated_at"`
 }
 
 // apiResponse wraps API responses.
@@ -74,13 +74,13 @@ type apiResponse struct {
 }
 
 type apiError struct {
-	Code    string                 `json:"code"`
-	Message string                 `json:"message"`
-	Details map[string]interface{} `json:"details,omitempty"`
+	Code    string         `json:"code"`
+	Message string         `json:"message"`
+	Details map[string]any `json:"details,omitempty"`
 }
 
 // request makes an HTTP request to the cloud server.
-func (c *Client) request(method, path string, body interface{}) ([]byte, error) {
+func (c *Client) request(method, path string, body any) ([]byte, error) {
 	var bodyReader io.Reader
 	if body != nil {
 		data, err := json.Marshal(body)

--- a/internal/config/types_definitions.go
+++ b/internal/config/types_definitions.go
@@ -263,6 +263,17 @@ const (
 	BrowserFirefox BrowserType = "firefox"
 )
 
+// SecretFileSource specifies which secret provider to use for a secret file.
+// Exactly one provider field must be set.
+type SecretFileSource struct {
+	Bitwarden         string `yaml:"bitwarden,omitempty" mapstructure:"bitwarden"`
+	OnePassword       string `yaml:"onepassword,omitempty" mapstructure:"onepassword"`
+	Vault             string `yaml:"vault,omitempty" mapstructure:"vault"`
+	AWSSecretsManager string `yaml:"aws_secrets_manager,omitempty" mapstructure:"aws_secrets_manager"`
+	AWSSSM            string `yaml:"aws_ssm,omitempty" mapstructure:"aws_ssm"`
+	GCPSecretManager  string `yaml:"gcp_secret_manager,omitempty" mapstructure:"gcp_secret_manager"`
+}
+
 // SecretsConfig holds configuration for fetching secrets from various providers.
 // Each provider has its own sub-section with ENV_VAR: "item-name" mappings.
 type SecretsConfig struct {
@@ -274,6 +285,8 @@ type SecretsConfig struct {
 	AWSSecretsManager map[string]string `yaml:"aws_secrets_manager,omitempty" mapstructure:"aws_secrets_manager"` // ENV_VAR: "secret-name" or "secret-name#json-key"
 	AWSSSM            map[string]string `yaml:"aws_ssm,omitempty" mapstructure:"aws_ssm"`                         // ENV_VAR: "/param/path"
 	GCPSecretManager  map[string]string `yaml:"gcp_secret_manager,omitempty" mapstructure:"gcp_secret_manager"`   // ENV_VAR: "secret-name" or "projects/p/secrets/s/versions/v"
+	// Secret Files: fetch secret content and write to a secure temp file, export file path as env var
+	Files map[string]SecretFileSource `yaml:"files,omitempty" mapstructure:"files"` // ENV_VAR: SecretFileSource
 }
 
 // BrowserConfig holds browser profile configuration.


### PR DESCRIPTION
feat(secrets): add secrets.files support for writing secrets to temp files

Fetch secret content from any supported provider (Vault, 1Password, Bitwarden, AWS Secrets Manager, AWS SSM, GCP Secret Manager), write it to a secure temp file (/dev/shm on Linux, os.TempDir fallback), and export the file path as an environment variable. Files are created with 0600 permissions and securely deleted (zero-filled) on deactivate and logout.

After resolving secret files, variable interpolation is re-run so that config fields like kubernetes.kubeconfig can reference ${KUBECONFIG} and resolve to the temp file path.
