### PR TITLE
feat(vpn): add NetBird VPN support with cloud and self-hosted instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ ctx use acme-prod
 | **Cloud Providers** | AWS, GCP, Azure profile switching with auto-login support |
 | **Orchestration** | Kubernetes, Nomad, Consul context management |
 | **Networking** | SSH tunnels with auto-reconnect, per-tunnel management |
-| **VPN** | OpenVPN, WireGuard, Tailscale, custom commands |
+| **VPN** | OpenVPN, WireGuard, Tailscale, NetBird, custom commands |
 | **Secrets** | Bitwarden, 1Password, Vault, AWS Secrets Manager, AWS SSM, GCP Secret Manager |
 | **Identity** | Per-context Git user configuration |
 | **Registries** | Docker and NPM registry configuration |
@@ -96,7 +96,7 @@ Full documentation is available at **[vlebo.github.io/ctx](https://vlebo.github.
 - [CLI Reference](https://vlebo.github.io/ctx/commands/) - All available commands
 - [AWS Setup](https://vlebo.github.io/ctx/cloud/aws/) - SSO, aws-vault, Secrets Manager
 - [Secrets Management](https://vlebo.github.io/ctx/secrets/) - Bitwarden, 1Password, Vault, and more
-- [VPN](https://vlebo.github.io/ctx/features/vpn/) - OpenVPN, WireGuard, Tailscale
+- [VPN](https://vlebo.github.io/ctx/features/vpn/) - OpenVPN, WireGuard, Tailscale, NetBird
 - [SSH Tunnels](https://vlebo.github.io/ctx/features/tunnels/) - Auto-connect tunnels
 - [Tips & Best Practices](https://vlebo.github.io/ctx/guides/tips/) - Production safety, credential isolation
 

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -124,10 +124,13 @@ See [SSH Tunnels](../features/tunnels.md) for details.
 
 ```yaml
 vpn:
-  type: string              # openvpn, wireguard, tailscale, custom
+  type: string              # openvpn, wireguard, tailscale, netbird, custom
   config_file: string       # Path to VPN config file
   interface: string         # WireGuard interface name
   exit_node: string         # Tailscale exit node
+  management_url: string    # NetBird management URL (optional, for self-hosted)
+  setup_key: string         # NetBird setup key (optional)
+  profile: string           # NetBird client profile name (optional)
   connect_cmd: string       # Custom connect command
   disconnect_cmd: string    # Custom disconnect command
   status_cmd: string        # Custom status command

--- a/docs/features/vpn.md
+++ b/docs/features/vpn.md
@@ -1,12 +1,12 @@
 # VPN
 
-ctx can automatically connect and disconnect VPN when switching contexts. Supports OpenVPN, WireGuard, Tailscale, and custom VPN solutions.
+ctx can automatically connect and disconnect VPN when switching contexts. Supports OpenVPN, WireGuard, Tailscale, NetBird, and custom VPN solutions.
 
 ## Configuration
 
 ```yaml
 vpn:
-  type: openvpn                   # openvpn, wireguard, tailscale, custom
+  type: openvpn                   # openvpn, wireguard, tailscale, netbird, custom
   config_file: ~/vpn/myproject.ovpn
   auto_connect: true              # Connect automatically on context switch
   auto_disconnect: true           # Disconnect when switching away
@@ -45,6 +45,24 @@ vpn:
   exit_node: us-west-1              # Optional exit node
   auto_connect: true
 ```
+
+### NetBird
+
+```yaml
+vpn:
+  type: netbird
+  profile: my-profile                      # Optional, NetBird client profile name
+  management_url: https://vpn.example.com  # Optional, for self-hosted NetBird
+  setup_key: "XXXXXXXX-XXXX-..."           # Optional, for headless auth
+  auto_connect: true
+```
+
+NetBird is an open-source WireGuard-based VPN/network mesh tool. Supports both [NetBird Cloud](https://netbird.io) and self-hosted instances. The `management_url` option specifies the management server (defaults to NetBird Cloud if omitted). The `setup_key` enables headless/automated authentication. The `profile` field maps to `netbird up --profile` for switching between different NetBird accounts.
+
+ctx automatically creates NetBird profiles if they don't exist, and handles the disconnect/reconnect cycle when switching between contexts.
+
+!!! note "Switching between NetBird servers"
+    NetBird only supports one active connection at a time. If you switch between different NetBird servers (e.g., self-hosted and cloud), use separate **profiles** — each profile stores its own management URL, keys, and auth state. Create profiles with `netbird profile add <name>`, then set the `profile` field in each context. Always set `management_url` explicitly in **both** contexts when using different servers.
 
 ### Custom VPN
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ Switch between AWS profiles, Kubernetes clusters, VPN connections, and SSH tunne
 | **Cloud Providers** | AWS, GCP, Azure profile switching with auto-login support |
 | **Orchestration** | Kubernetes, Nomad, Consul context management |
 | **Networking** | SSH tunnels with auto-reconnect, per-tunnel management |
-| **VPN** | OpenVPN, WireGuard, Tailscale, custom commands |
+| **VPN** | OpenVPN, WireGuard, Tailscale, NetBird, custom commands |
 | **Secrets** | Bitwarden, 1Password, Vault, AWS Secrets Manager, AWS SSM, GCP Secret Manager |
 | **Identity** | Per-context Git user configuration |
 | **Registries** | Docker and NPM registry configuration |

--- a/internal/cli/switchers.go
+++ b/internal/cli/switchers.go
@@ -15,7 +15,7 @@ import (
 )
 
 // switchVPN connects to VPN based on configuration.
-func switchVPN(cfg *config.VPNConfig) error {
+func switchVPN(cfg *config.VPNConfig, browser *config.BrowserConfig) error {
 	if cfg == nil {
 		return nil
 	}
@@ -27,6 +27,8 @@ func switchVPN(cfg *config.VPNConfig) error {
 		return switchWireGuard(cfg)
 	case config.VPNTypeTailscale:
 		return switchTailscale(cfg)
+	case config.VPNTypeNetbird:
+		return switchNetbird(cfg, browser)
 	case config.VPNTypeCustom:
 		return switchCustomVPN(cfg)
 	default:
@@ -172,6 +174,80 @@ func switchTailscale(cfg *config.VPNConfig) error {
 	return nil
 }
 
+func switchNetbird(cfg *config.VPNConfig, browser *config.BrowserConfig) error {
+	if _, err := exec.LookPath("netbird"); err != nil {
+		return fmt.Errorf("netbird command not found in PATH")
+	}
+
+	// NetBird only supports a single connection. If already connected (possibly
+	// to a different management server), disconnect first so we can reconnect
+	// with the correct parameters.
+	cmd := exec.Command("netbird", "status")
+	if output, err := cmd.Output(); err == nil && strings.Contains(string(output), "Management: Connected") {
+		down := exec.Command("netbird", "down")
+		if err := down.Run(); err != nil {
+			down = exec.Command("sudo", "netbird", "down")
+			down.Run()
+		}
+	}
+
+	// Ensure the profile exists before connecting
+	if cfg.Profile != "" {
+		// Check if profile exists by listing profiles
+		listCmd := exec.Command("netbird", "profile", "list")
+		if output, err := listCmd.Output(); err == nil {
+			if !strings.Contains(string(output), cfg.Profile) {
+				// Profile doesn't exist, create it
+				addCmd := exec.Command("netbird", "profile", "add", cfg.Profile)
+				if err := addCmd.Run(); err != nil {
+					addCmd = exec.Command("sudo", "netbird", "profile", "add", cfg.Profile)
+					addCmd.Run()
+				}
+			}
+		}
+	}
+
+	args := []string{"up"}
+	if cfg.Profile != "" {
+		args = append(args, "--profile", cfg.Profile)
+	}
+	if cfg.ManagementURL != "" {
+		args = append(args, "--management-url", cfg.ManagementURL)
+	}
+	if cfg.SetupKey != "" {
+		args = append(args, "--setup-key", cfg.SetupKey)
+	}
+
+	// Set BROWSER env var to use the configured browser profile for NetBird SSO auth
+	// (not needed when setup_key is provided — authentication is headless)
+	var extraEnv []string
+	if browser != nil && cfg.SetupKey == "" {
+		browserCmd := getBrowserCommand(browser)
+		if browserCmd != "" {
+			extraEnv = append(extraEnv, "BROWSER="+browserCmd)
+		}
+	}
+
+	// Try without sudo first
+	cmd = exec.Command("netbird", args...)
+	if len(extraEnv) > 0 {
+		cmd.Env = append(os.Environ(), extraEnv...)
+	}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		// Try with sudo
+		cmd = exec.Command("sudo", append([]string{"netbird"}, args...)...)
+		if len(extraEnv) > 0 {
+			cmd.Env = append(os.Environ(), extraEnv...)
+		}
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
+	}
+	return nil
+}
+
 func switchCustomVPN(cfg *config.VPNConfig) error {
 	if cfg.ConnectCmd == "" {
 		return fmt.Errorf("custom VPN connect_cmd is required")
@@ -230,6 +306,13 @@ func disconnectVPN(cfg *config.VPNConfig) error {
 		if err := cmd.Run(); err != nil {
 			// Try with sudo
 			cmd = exec.Command("sudo", "tailscale", "down")
+			cmd.Run() // Ignore errors - might already be disconnected
+		}
+		return nil
+	case config.VPNTypeNetbird:
+		cmd := exec.Command("netbird", "down")
+		if err := cmd.Run(); err != nil {
+			cmd = exec.Command("sudo", "netbird", "down")
 			cmd.Run() // Ignore errors - might already be disconnected
 		}
 		return nil
@@ -508,6 +591,14 @@ func checkAnyVPNRunning(expected *config.VPNConfig) string {
 		}
 	}
 
+	// Check netbird
+	cmd = exec.Command("netbird", "status")
+	if output, err := cmd.Output(); err == nil {
+		if strings.Contains(string(output), "Management: Connected") {
+			return "netbird"
+		}
+	}
+
 	return ""
 }
 
@@ -531,6 +622,12 @@ func checkVPNStatus(cfg *config.VPNConfig) bool {
 		cmd := exec.Command("tailscale", "status", "--json")
 		output, err := cmd.Output()
 		if err == nil && strings.Contains(string(output), `"BackendState":"Running"`) {
+			return true
+		}
+	case config.VPNTypeNetbird:
+		cmd := exec.Command("netbird", "status")
+		output, err := cmd.Output()
+		if err == nil && strings.Contains(string(output), "Management: Connected") {
 			return true
 		}
 	case config.VPNTypeOpenVPN:

--- a/internal/cli/switchers_test.go
+++ b/internal/cli/switchers_test.go
@@ -35,9 +35,9 @@ func TestExpandPath(t *testing.T) {
 }
 
 func TestSwitchVPN_NilConfig(t *testing.T) {
-	err := switchVPN(nil)
+	err := switchVPN(nil, nil)
 	if err != nil {
-		t.Errorf("switchVPN(nil) = %v, want nil", err)
+		t.Errorf("switchVPN(nil, nil) = %v, want nil", err)
 	}
 }
 
@@ -46,7 +46,7 @@ func TestSwitchVPN_UnsupportedType(t *testing.T) {
 		Type: "unsupported",
 	}
 
-	err := switchVPN(cfg)
+	err := switchVPN(cfg, nil)
 	if err == nil {
 		t.Error("Expected error for unsupported VPN type")
 	}
@@ -57,7 +57,7 @@ func TestSwitchVPN_CustomWithoutCmd(t *testing.T) {
 		Type: config.VPNTypeCustom,
 	}
 
-	err := switchVPN(cfg)
+	err := switchVPN(cfg, nil)
 	if err == nil {
 		t.Error("Expected error for custom VPN without connect_cmd")
 	}
@@ -106,6 +106,22 @@ func TestSwitchOpenVPN_NoConfigFile(t *testing.T) {
 	err := switchOpenVPN(cfg)
 	if err == nil {
 		t.Error("Expected error when config_file is not set")
+	}
+}
+
+func TestSwitchNetbird_NoBinary(t *testing.T) {
+	// Ensure netbird is not in PATH
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", "/nonexistent")
+	defer os.Setenv("PATH", origPath)
+
+	cfg := &config.VPNConfig{
+		Type: config.VPNTypeNetbird,
+	}
+
+	err := switchNetbird(cfg, nil)
+	if err == nil {
+		t.Error("Expected error when netbird is not in PATH")
 	}
 }
 

--- a/internal/cli/use.go
+++ b/internal/cli/use.go
@@ -135,11 +135,11 @@ func switchContext(mgr *config.Manager, ctx *config.ContextConfig) ([]string, er
 
 	// Connect VPN first (if configured with auto_connect)
 	if ctx.VPN != nil && ctx.VPN.AutoConnect {
-		// Skip if this VPN is already connected
-		if checkVPNStatus(ctx.VPN) {
+		// NetBird always reconnects (forced down/up) to ensure correct profile/server
+		if ctx.VPN.Type != config.VPNTypeNetbird && checkVPNStatus(ctx.VPN) {
 			green := color.New(color.FgGreen)
 			green.Fprintf(os.Stderr, "✓ VPN already connected\n")
-		} else if err := switchVPN(ctx.VPN); err != nil {
+		} else if err := switchVPN(ctx.VPN, ctx.Browser); err != nil {
 			yellow.Fprintf(os.Stderr, "⚠ VPN connection failed: %v\n", err)
 			failures = append(failures, "VPN")
 		}

--- a/internal/cli/vpn.go
+++ b/internal/cli/vpn.go
@@ -72,7 +72,7 @@ func runVPNConnect(cmd *cobra.Command, args []string) error {
 	green := color.New(color.FgGreen)
 	fmt.Printf("Connecting to VPN (%s)...\n", ctx.VPN.Type)
 
-	if err := switchVPN(ctx.VPN); err != nil {
+	if err := switchVPN(ctx.VPN, ctx.Browser); err != nil {
 		// Send failure event
 		sendVPNEvent(mgr, ctx.Name, string(ctx.Environment), "vpn.connect", false, err.Error())
 		return fmt.Errorf("VPN connection failed: %w", err)

--- a/internal/config/types_definitions.go
+++ b/internal/config/types_definitions.go
@@ -140,6 +140,7 @@ const (
 	VPNTypeOpenVPN   VPNType = "openvpn"
 	VPNTypeWireGuard VPNType = "wireguard"
 	VPNTypeTailscale VPNType = "tailscale"
+	VPNTypeNetbird   VPNType = "netbird"
 	VPNTypeCustom    VPNType = "custom"
 )
 
@@ -153,6 +154,10 @@ type VPNConfig struct {
 	Interface string `yaml:"interface,omitempty" mapstructure:"interface"`
 	// Tailscale
 	ExitNode string `yaml:"exit_node,omitempty" mapstructure:"exit_node"`
+	// NetBird
+	ManagementURL string `yaml:"management_url,omitempty" mapstructure:"management_url"`
+	SetupKey      string `yaml:"setup_key,omitempty" mapstructure:"setup_key"`
+	Profile       string `yaml:"profile,omitempty" mapstructure:"profile"`
 	// Custom commands
 	ConnectCmd    string `yaml:"connect_cmd,omitempty" mapstructure:"connect_cmd"`
 	DisconnectCmd string `yaml:"disconnect_cmd,omitempty" mapstructure:"disconnect_cmd"`


### PR DESCRIPTION
- Supports management_url (self-hosted), setup_key (headless auth), and profile (switching between accounts/servers).
-  Profiles are auto-created if they don't exist.
- Browser profile config is respected for SSO auth.