### PR TITLE
feat(git): add ssh_key config to control which SSH key is used for Git operations

### DIFF
--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -214,6 +214,7 @@ git:
   user_email: string        # Git author/committer email
   signing_key: string       # GPG key ID for signing
   gpg_sign: bool            # Enable commit signing
+  ssh_key: string           # Path to SSH private key for Git operations (sets GIT_SSH_COMMAND)
 ```
 
 ## Docker

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -71,6 +71,7 @@ See [HashiCorp Vault](secrets/vault.md) for details.
 | `GIT_AUTHOR_EMAIL` | Git commit author email |
 | `GIT_COMMITTER_NAME` | Git committer name |
 | `GIT_COMMITTER_EMAIL` | Git committer email |
+| `GIT_SSH_COMMAND` | SSH command with identity key for Git operations |
 
 ## Databases
 

--- a/examples/with-inheritance.yaml
+++ b/examples/with-inheritance.yaml
@@ -19,6 +19,7 @@
 #
 # git:
 #   user_email: "you@acme.com"
+#   ssh_key: ~/.ssh/acme_ed25519
 #
 # urls:
 #   jira: https://acme.atlassian.net

--- a/internal/cli/deactivate.go
+++ b/internal/cli/deactivate.go
@@ -104,7 +104,8 @@ func runDeactivate(cmd *cobra.Command, args []string) error {
 			// Vault
 			"VAULT_ADDR", "VAULT_NAMESPACE", "VAULT_SKIP_VERIFY", "VAULT_TOKEN",
 			// Git
-			"GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL", "GIT_COMMITTER_NAME", "GIT_COMMITTER_EMAIL",
+			"GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL", "GIT_COMMITTER_NAME", "GIT_COMMITTER_EMAIL", "GIT_SSH_COMMAND",
+			"GIT_CONFIG_COUNT", "GIT_CONFIG_KEY_0", "GIT_CONFIG_VALUE_0", "GIT_CONFIG_KEY_1", "GIT_CONFIG_VALUE_1",
 			// Proxy
 			"HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy", "NO_PROXY", "no_proxy",
 			// Databases

--- a/internal/cli/switchers.go
+++ b/internal/cli/switchers.go
@@ -412,44 +412,11 @@ func verifyVaultToken(cfg *config.VaultConfig, token string) bool {
 }
 
 // switchGit configures Git identity for the session.
+// All Git configuration is handled via environment variables (GIT_AUTHOR_NAME,
+// GIT_AUTHOR_EMAIL, GIT_COMMITTER_NAME, GIT_COMMITTER_EMAIL, GIT_SSH_COMMAND)
+// set in GenerateEnvVars. This avoids polluting ~/.gitconfig with global settings
+// that persist beyond the context session.
 func switchGit(cfg *config.GitConfig) error {
-	if cfg == nil {
-		return nil
-	}
-
-	if _, err := exec.LookPath("git"); err != nil {
-		return nil // Git not available
-	}
-
-	// Set git config globally for this session via environment variables
-	// This is handled in GenerateEnvVars, but we can also set them directly
-
-	if cfg.UserName != "" {
-		cmd := exec.Command("git", "config", "--global", "user.name", cfg.UserName)
-		if err := cmd.Run(); err != nil {
-			yellow := color.New(color.FgYellow)
-			yellow.Printf("⚠ Failed to set git user.name: %v\n", err)
-		}
-	}
-
-	if cfg.UserEmail != "" {
-		cmd := exec.Command("git", "config", "--global", "user.email", cfg.UserEmail)
-		if err := cmd.Run(); err != nil {
-			yellow := color.New(color.FgYellow)
-			yellow.Printf("⚠ Failed to set git user.email: %v\n", err)
-		}
-	}
-
-	if cfg.SigningKey != "" {
-		cmd := exec.Command("git", "config", "--global", "user.signingkey", cfg.SigningKey)
-		cmd.Run()
-	}
-
-	if cfg.GPGSign {
-		cmd := exec.Command("git", "config", "--global", "commit.gpgsign", "true")
-		cmd.Run()
-	}
-
 	return nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -494,6 +494,26 @@ func (m *Manager) GenerateEnvVars(ctx *ContextConfig) map[string]string {
 			envVars["GIT_AUTHOR_EMAIL"] = ctx.Git.UserEmail
 			envVars["GIT_COMMITTER_EMAIL"] = ctx.Git.UserEmail
 		}
+		if ctx.Git.SSHKey != "" {
+			keyPath := expandPath(ctx.Git.SSHKey)
+			envVars["GIT_SSH_COMMAND"] = fmt.Sprintf("ssh -i %s -o IdentitiesOnly=yes", keyPath)
+		}
+		// Use GIT_CONFIG_COUNT/KEY/VALUE to set config values via env vars
+		// without polluting ~/.gitconfig (requires Git 2.31+)
+		configIdx := 0
+		if ctx.Git.SigningKey != "" {
+			envVars[fmt.Sprintf("GIT_CONFIG_KEY_%d", configIdx)] = "user.signingkey"
+			envVars[fmt.Sprintf("GIT_CONFIG_VALUE_%d", configIdx)] = ctx.Git.SigningKey
+			configIdx++
+		}
+		if ctx.Git.GPGSign {
+			envVars[fmt.Sprintf("GIT_CONFIG_KEY_%d", configIdx)] = "commit.gpgsign"
+			envVars[fmt.Sprintf("GIT_CONFIG_VALUE_%d", configIdx)] = "true"
+			configIdx++
+		}
+		if configIdx > 0 {
+			envVars["GIT_CONFIG_COUNT"] = fmt.Sprintf("%d", configIdx)
+		}
 	}
 
 	// Proxy

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -564,6 +564,47 @@ func TestManager_GenerateEnvVars_Kubernetes(t *testing.T) {
 	}
 }
 
+func TestManager_GenerateEnvVars_GitSSHKey(t *testing.T) {
+	tmpDir := t.TempDir()
+	m := NewManagerWithDir(tmpDir)
+
+	ctx := &ContextConfig{
+		Name: "git-ssh-test",
+		Git: &GitConfig{
+			UserName: "Test User",
+			UserEmail: "test@example.com",
+			SSHKey:   "/home/test/.ssh/work_key",
+		},
+	}
+
+	envVars := m.GenerateEnvVars(ctx)
+
+	if envVars["GIT_AUTHOR_NAME"] != "Test User" {
+		t.Errorf("envVars[GIT_AUTHOR_NAME] = %v, want Test User", envVars["GIT_AUTHOR_NAME"])
+	}
+	if envVars["GIT_AUTHOR_EMAIL"] != "test@example.com" {
+		t.Errorf("envVars[GIT_AUTHOR_EMAIL] = %v, want test@example.com", envVars["GIT_AUTHOR_EMAIL"])
+	}
+
+	expected := "ssh -i /home/test/.ssh/work_key -o IdentitiesOnly=yes"
+	if envVars["GIT_SSH_COMMAND"] != expected {
+		t.Errorf("envVars[GIT_SSH_COMMAND] = %v, want %v", envVars["GIT_SSH_COMMAND"], expected)
+	}
+
+	// Test without ssh_key - GIT_SSH_COMMAND should not be set
+	ctx2 := &ContextConfig{
+		Name: "git-no-ssh-test",
+		Git: &GitConfig{
+			UserName: "Test User",
+		},
+	}
+
+	envVars2 := m.GenerateEnvVars(ctx2)
+	if _, exists := envVars2["GIT_SSH_COMMAND"]; exists {
+		t.Errorf("envVars[GIT_SSH_COMMAND] should not be set when ssh_key is empty")
+	}
+}
+
 func TestManager_WriteEnvFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	m := NewManagerWithDir(tmpDir)

--- a/internal/config/types_definitions.go
+++ b/internal/config/types_definitions.go
@@ -213,6 +213,7 @@ type GitConfig struct {
 	UserEmail  string `yaml:"user_email,omitempty" mapstructure:"user_email"`
 	SigningKey string `yaml:"signing_key,omitempty" mapstructure:"signing_key"`
 	GPGSign    bool   `yaml:"gpg_sign,omitempty" mapstructure:"gpg_sign"`
+	SSHKey     string `yaml:"ssh_key,omitempty" mapstructure:"ssh_key"` // Path to SSH private key for Git operations
 }
 
 // DockerRegistryConfig holds Docker registry configuration.


### PR DESCRIPTION

Sets GIT_SSH_COMMAND and core.sshCommand with IdentitiesOnly=yes to prevent identity mismatch when multiple SSH keys are loaded (e.g., personal vs work GitHub accounts).