### PR TITLE
bugfix: kubeconfig isolation

### DIFF
--- a/internal/cli/use.go
+++ b/internal/cli/use.go
@@ -796,10 +796,14 @@ func switchKubernetes(cfg *config.KubernetesConfig, ctx *config.ContextConfig, m
 	yellow := color.New(color.FgYellow)
 	green := color.New(color.FgGreen)
 
-	// Expand kubeconfig path if specified
+	// Expand kubeconfig path if specified, otherwise auto-isolate per-context
+	// when a cloud provider (AKS/EKS/GKE) is configured. This prevents kubectl
+	// context state from leaking into ~/.kube/config across shells.
 	kubeconfigPath := cfg.Kubeconfig
 	if kubeconfigPath != "" {
 		kubeconfigPath = expandPath(kubeconfigPath)
+	} else if cfg.AKS != nil || cfg.EKS != nil || cfg.GKE != nil {
+		kubeconfigPath = mgr.KubeconfigPath(ctx.Name)
 	}
 
 	// Fetch credentials from cloud provider if configured

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -89,6 +89,21 @@ func (m *Manager) StateDir() string {
 	return m.stateDir
 }
 
+// KubeconfigPath returns the per-context kubeconfig file path used for
+// auto-isolated cloud kubernetes configurations.
+func (m *Manager) KubeconfigPath(contextName string) string {
+	return filepath.Join(m.stateDir, "kubeconfig-"+contextName)
+}
+
+// hasCloudKubernetesConfig reports whether a kubernetes config has any cloud
+// provider block (AKS/EKS/GKE) that generates its own kubeconfig contents.
+func hasCloudKubernetesConfig(k *KubernetesConfig) bool {
+	if k == nil {
+		return false
+	}
+	return k.AKS != nil || k.EKS != nil || k.GKE != nil
+}
+
 // EnsureDirs creates the configuration directories if they don't exist.
 func (m *Manager) EnsureDirs() error {
 	dirs := []string{m.configDir, m.contextsDir, m.stateDir}
@@ -440,6 +455,11 @@ func (m *Manager) GenerateEnvVars(ctx *ContextConfig) map[string]string {
 	if ctx.Kubernetes != nil {
 		if ctx.Kubernetes.Kubeconfig != "" {
 			envVars["KUBECONFIG"] = expandPath(ctx.Kubernetes.Kubeconfig)
+		} else if hasCloudKubernetesConfig(ctx.Kubernetes) {
+			// Auto-isolate kubeconfig per-context when a cloud provider
+			// (AKS/EKS/GKE) is configured, so kubectl context state doesn't
+			// leak into ~/.kube/config across shells.
+			envVars["KUBECONFIG"] = m.KubeconfigPath(ctx.Name)
 		}
 	}
 


### PR DESCRIPTION
 fix(kubernetes): auto-isolate kubeconfig per-context for cloud providers

When a kubernetes config has an AKS/EKS/GKE block but no explicit kubeconfig path, default KUBECONFIG to a per-context file under the state directory. This prevents kubectl context state from leaking into `~/.kube/config` across shells, matching how CLOUDSDK_CONFIG already isolates gcloud state per-context.

Contexts with an explicit `kubernetes.kubeconfig:` are unchanged. Plain context-only configs (no cloud block) also unchanged, since the context already lives in `~/.kube/config`.
