### PR TITLE
feat(tunnel): add AWS SSM tunnel support via Session Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.14] - 2026-04-19
+
+### Features
+
+- **AWS SSM Tunnels**: Port-forward to VPC resources via AWS Session Manager — no SSH port, no bastion key, just IAM credentials. Tunnels are configured under `aws.tunnels`, run as subprocesses (`aws ssm start-session`), and support `auto_connect`. ctx verifies that both `aws` CLI v2 and `session-manager-plugin` are installed before attempting any connection, and validates the target instance is registered in SSM before opening the tunnel interactively.
+
 ## [0.1.8] - 2026-02-17
 
 ### Bug Fixes

--- a/docs/cloud/aws.md
+++ b/docs/cloud/aws.md
@@ -157,6 +157,25 @@ secrets:
 
 Parameters are automatically decrypted if they're SecureString type.
 
+## SSM Tunnels
+
+ctx can open port-forwarding tunnels to VPC resources via AWS Session Manager — no SSH port, no bastion key. Tunnels are configured under `aws.tunnels` and use the same AWS credentials as the rest of the context.
+
+```yaml
+aws:
+  profile: myproject-prod
+  region: eu-west-1
+  tunnels:
+    - name: postgres
+      ssm_target: i-0abc123def456789a
+      remote_host: db.internal.vpc
+      remote_port: 5432
+      local_port: 5432
+      auto_connect: true
+```
+
+See [Tunnels](../features/tunnels.md#aws-ssm-tunnels) for full configuration reference and requirements.
+
 ## Credential Isolation
 
 When using aws-vault, ctx stores temporary credentials per-context:

--- a/docs/cloud/aws.md
+++ b/docs/cloud/aws.md
@@ -157,6 +157,27 @@ secrets:
 
 Parameters are automatically decrypted if they're SecureString type.
 
+## AWS Tunnels
+
+ctx can open port-forwarding tunnels to VPC resources via AWS Session Manager — no SSH port, no bastion key. Tunnels are configured under `tunnels:` with `type: aws` and use the same AWS credentials as the rest of the context.
+
+```yaml
+aws:
+  profile: myproject-prod
+  region: eu-west-1
+
+tunnels:
+  - name: postgres
+    type: aws
+    target: i-0abc123def456789a
+    remote_host: db.internal.vpc
+    remote_port: 5432
+    local_port: 5432
+    auto_connect: true
+```
+
+See [Tunnels](../features/tunnels.md#aws-tunnels) for full configuration reference and requirements.
+
 ## Credential Isolation
 
 When using aws-vault, ctx stores temporary credentials per-context:

--- a/docs/features/tunnels.md
+++ b/docs/features/tunnels.md
@@ -1,8 +1,12 @@
-# SSH Tunnels
+# Tunnels
 
-ctx manages SSH tunnels per context with automatic connection, health monitoring, and reconnection.
+ctx manages tunnels per context with automatic connection and health monitoring. Two transport types are supported: **SSH** (via a bastion host) and **AWS SSM** (via Session Manager, no SSH port required).
 
-## Configuration
+## SSH Tunnels
+
+SSH tunnels use a bastion host to forward ports to resources inside a private network.
+
+### Configuration
 
 ```yaml
 ssh:
@@ -33,7 +37,7 @@ tunnels:
     remote_port: 4646
 ```
 
-## Commands
+### Commands
 
 ```bash
 ctx tunnel list                  # List defined tunnels for current context
@@ -44,7 +48,7 @@ ctx tunnel down <name>           # Stop specific tunnel
 ctx tunnel status                # Show running tunnel status
 ```
 
-## Bastion Configuration
+### Bastion Configuration
 
 The `ssh.bastion` section defines the jump host used for all tunnels:
 
@@ -58,7 +62,7 @@ ssh:
   tunnel_timeout: 5              # Seconds to wait for connection (default: 5)
 ```
 
-## Tunnel Options
+### Tunnel Options
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -69,7 +73,7 @@ ssh:
 | `remote_port` | int | **Required.** Remote port |
 | `auto_connect` | bool | Start automatically on context switch |
 
-## Auto-Connect
+### Auto-Connect
 
 When `auto_connect: true` on a tunnel:
 
@@ -77,7 +81,7 @@ When `auto_connect: true` on a tunnel:
 - Tunnel starts after VPN connection (if configured)
 - Tunnel stops when you switch contexts or run `ctx deactivate`
 
-## Database Access via Tunnels
+### Database Access via Tunnels
 
 A common pattern is to combine tunnels with database configuration:
 
@@ -114,7 +118,7 @@ psql -h localhost -U app_user -d production
 # Connected via tunnel to db.internal
 ```
 
-## Multiple Tunnels
+### Multiple Tunnels
 
 You can define multiple tunnels per context:
 
@@ -147,7 +151,7 @@ ctx tunnel up                    # Start all tunnels
 ctx tunnel down elasticsearch    # Stop just elasticsearch
 ```
 
-## Tunnel Status
+### Tunnel Status
 
 Check which tunnels are running:
 
@@ -162,7 +166,7 @@ Output shows:
 - Connection status (running/stopped)
 - Process ID if running
 
-## Health Monitoring
+### Health Monitoring
 
 ctx monitors tunnel health and automatically reconnects if:
 
@@ -170,7 +174,7 @@ ctx monitors tunnel health and automatically reconnects if:
 - The bastion host becomes unreachable
 - The tunnel process crashes
 
-## Inheritance
+### Inheritance
 
 Tunnels are replaced (not merged) when using context inheritance. If a child context defines any tunnels, it completely replaces the parent's tunnel list.
 
@@ -193,3 +197,125 @@ tunnels:
 ```
 
 To include parent tunnels, you must redefine them in the child context.
+
+---
+
+## AWS SSM Tunnels
+
+SSM tunnels use [AWS Session Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager.html) to forward ports to resources inside a VPC — no open SSH port, no bastion key, just IAM credentials.
+
+### Requirements
+
+**On the EC2 bastion instance:**
+
+- SSM Agent installed and running
+- IAM instance profile with `AmazonSSMManagedInstanceCore` policy
+- No inbound rules required in the security group (only HTTPS outbound to SSM endpoints)
+
+**On your local machine (ctx checks these before starting any SSM tunnel):**
+
+- [AWS CLI v2](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) — `aws --version` must return `aws-cli/2.x`
+- [session-manager-plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html) — must be in PATH
+
+### Configuration
+
+SSM tunnels live under `aws.tunnels`, separate from SSH tunnels:
+
+```yaml
+aws:
+  profile: myproject-prod
+  region: eu-west-1
+  sso_login: true
+  tunnels:
+    - name: postgres
+      ssm_target: i-0abc123def456789a   # EC2 instance ID of the bastion
+      remote_host: db.internal.vpc
+      remote_port: 5432
+      local_port: 5432
+      auto_connect: true
+
+    - name: redis
+      ssm_target: i-0abc123def456789a
+      remote_host: cache.internal.vpc
+      remote_port: 6379
+      local_port: 6379
+```
+
+!!! note
+    SSH tunnels (under `tunnels:`) and SSM tunnels (under `aws.tunnels:`) are independent. Both can coexist in the same context.
+
+### Tunnel Options
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | **Required.** Tunnel identifier |
+| `description` | string | Human-readable description |
+| `ssm_target` | string | **Required.** EC2 instance ID (`i-xxxxxxxxxxxxxxxxx`) |
+| `remote_host` | string | **Required.** Remote host inside the VPC |
+| `remote_port` | int | **Required.** Remote port |
+| `local_port` | int | **Required.** Local port to bind |
+| `auto_connect` | bool | Start automatically on context switch |
+
+### Commands
+
+The same tunnel commands work for both SSH and SSM tunnels:
+
+```bash
+ctx tunnel list                  # Shows both SSH and SSM tunnels (TYPE column)
+ctx tunnel up                    # Start all tunnels (SSH + SSM)
+ctx tunnel up postgres           # Start specific SSM tunnel by name
+ctx tunnel down                  # Stop all tunnels
+ctx tunnel status                # Shows TYPE column: ssh / ssm
+```
+
+### Authentication
+
+SSM tunnels inherit the AWS authentication configured in the `aws:` section. Credentials are injected explicitly into the subprocess environment — they work correctly even during `auto_connect` (before the shell hook sources the env file).
+
+| Auth method | How it works |
+|-------------|--------------|
+| Named profile (`profile`) | `AWS_PROFILE` injected |
+| aws-vault (`use_vault: true`) | Temporary credentials injected from cache |
+| SSO (`sso_login: true`) | Profile set after SSO login completes |
+
+### Pre-connection Check
+
+When starting a tunnel interactively (`ctx tunnel up`), ctx calls `aws ssm describe-instance-information` to verify the target instance is registered in SSM before any connection attempt. If it is not, you will see a clear error:
+
+```
+instance "i-0abc123def456789a" is not registered in SSM — verify the SSM Agent
+is running and the instance profile has AmazonSSMManagedInstanceCore
+```
+
+### Mixed Context Example
+
+SSH and SSM tunnels in the same context:
+
+```yaml
+name: myproject-prod
+environment: production
+
+aws:
+  profile: myproject-prod
+  region: eu-west-1
+  tunnels:
+    - name: postgres
+      ssm_target: i-0abc123def456789a
+      remote_host: db.internal.vpc
+      remote_port: 5432
+      local_port: 5432
+      auto_connect: true
+
+# Legacy SSH tunnel to a separate service
+ssh:
+  bastion:
+    host: legacy-bastion.example.com
+    user: deploy
+    identity_file: ~/.ssh/deploy_key
+
+tunnels:
+  - name: legacy-api
+    remote_host: api.internal
+    remote_port: 8080
+    local_port: 8080
+```

--- a/docs/features/tunnels.md
+++ b/docs/features/tunnels.md
@@ -1,8 +1,12 @@
-# SSH Tunnels
+# Tunnels
 
-ctx manages SSH tunnels per context with automatic connection, health monitoring, and reconnection.
+ctx manages tunnels per context with automatic connection and health monitoring. Two transport types are supported: **SSH** (via a bastion host) and **AWS** (via Session Manager, no SSH port required).
 
-## Configuration
+## SSH Tunnels
+
+SSH tunnels use a bastion host to forward ports to resources inside a private network.
+
+### Configuration
 
 ```yaml
 ssh:
@@ -33,7 +37,7 @@ tunnels:
     remote_port: 4646
 ```
 
-## Commands
+### Commands
 
 ```bash
 ctx tunnel list                  # List defined tunnels for current context
@@ -44,7 +48,7 @@ ctx tunnel down <name>           # Stop specific tunnel
 ctx tunnel status                # Show running tunnel status
 ```
 
-## Bastion Configuration
+### Bastion Configuration
 
 The `ssh.bastion` section defines the jump host used for all tunnels:
 
@@ -58,7 +62,7 @@ ssh:
   tunnel_timeout: 5              # Seconds to wait for connection (default: 5)
 ```
 
-## Tunnel Options
+### Tunnel Options
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -69,7 +73,7 @@ ssh:
 | `remote_port` | int | **Required.** Remote port |
 | `auto_connect` | bool | Start automatically on context switch |
 
-## Auto-Connect
+### Auto-Connect
 
 When `auto_connect: true` on a tunnel:
 
@@ -77,7 +81,7 @@ When `auto_connect: true` on a tunnel:
 - Tunnel starts after VPN connection (if configured)
 - Tunnel stops when you switch contexts or run `ctx deactivate`
 
-## Database Access via Tunnels
+### Database Access via Tunnels
 
 A common pattern is to combine tunnels with database configuration:
 
@@ -114,7 +118,7 @@ psql -h localhost -U app_user -d production
 # Connected via tunnel to db.internal
 ```
 
-## Multiple Tunnels
+### Multiple Tunnels
 
 You can define multiple tunnels per context:
 
@@ -147,7 +151,7 @@ ctx tunnel up                    # Start all tunnels
 ctx tunnel down elasticsearch    # Stop just elasticsearch
 ```
 
-## Tunnel Status
+### Tunnel Status
 
 Check which tunnels are running:
 
@@ -162,7 +166,7 @@ Output shows:
 - Connection status (running/stopped)
 - Process ID if running
 
-## Health Monitoring
+### Health Monitoring
 
 ctx monitors tunnel health and automatically reconnects if:
 
@@ -170,7 +174,7 @@ ctx monitors tunnel health and automatically reconnects if:
 - The bastion host becomes unreachable
 - The tunnel process crashes
 
-## Inheritance
+### Inheritance
 
 Tunnels are replaced (not merged) when using context inheritance. If a child context defines any tunnels, it completely replaces the parent's tunnel list.
 
@@ -193,3 +197,127 @@ tunnels:
 ```
 
 To include parent tunnels, you must redefine them in the child context.
+
+---
+
+## AWS Tunnels
+
+AWS tunnels use [AWS Session Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager.html) to forward ports to resources inside a VPC — no open SSH port, no bastion key, just IAM credentials.
+
+### Requirements
+
+**On the EC2 bastion instance:**
+
+- SSM Agent installed and running
+- IAM instance profile with `AmazonSSMManagedInstanceCore` policy
+- No inbound rules required in the security group (only HTTPS outbound to SSM endpoints)
+
+**On your local machine (ctx checks these before starting any AWS tunnel):**
+
+- [AWS CLI v2](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) — `aws --version` must return `aws-cli/2.x`
+- [session-manager-plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html) — must be in PATH
+
+### Configuration
+
+AWS tunnels live under `tunnels:` alongside SSH tunnels, distinguished by `type: aws`:
+
+```yaml
+aws:
+  profile: myproject-prod
+  region: eu-west-1
+  sso_login: true
+
+tunnels:
+  - name: postgres
+    type: aws
+    target: i-0abc123def456789a    # EC2 instance ID of the bastion
+    remote_host: db.internal.vpc
+    remote_port: 5432
+    local_port: 5432
+    auto_connect: true
+
+  - name: redis
+    type: aws
+    target: i-0abc123def456789a
+    remote_host: cache.internal.vpc
+    remote_port: 6379
+    local_port: 6379
+```
+
+### Tunnel Options
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | **Required.** Tunnel identifier |
+| `description` | string | Human-readable description |
+| `type` | string | `aws` for AWS Session Manager tunnels; omit or leave empty for SSH |
+| `target` | string | **Required for `type: aws`.** EC2 instance ID (`i-xxxxxxxxxxxxxxxxx`) |
+| `remote_host` | string | **Required.** Remote host inside the VPC |
+| `remote_port` | int | **Required.** Remote port |
+| `local_port` | int | **Required.** Local port to bind |
+| `auto_connect` | bool | Start automatically on context switch |
+
+### Commands
+
+The same tunnel commands work for both SSH and AWS tunnels:
+
+```bash
+ctx tunnel list                  # Shows all tunnels with TYPE column (ssh / aws)
+ctx tunnel up                    # Start all tunnels
+ctx tunnel up postgres           # Start a specific tunnel by name
+ctx tunnel down                  # Stop all tunnels
+ctx tunnel status                # Shows TYPE column: ssh / aws
+```
+
+### Authentication
+
+AWS tunnels inherit the authentication configured in the `aws:` section. Credentials are injected explicitly into the subprocess environment — they work correctly even during `auto_connect` (before the shell hook sources the env file).
+
+| Auth method | How it works |
+|-------------|--------------|
+| Named profile (`profile`) | `AWS_PROFILE` injected |
+| aws-vault (`use_vault: true`) | Temporary credentials injected from cache |
+| SSO (`sso_login: true`) | Profile set after SSO login completes |
+
+### Pre-connection Check
+
+When starting a tunnel interactively (`ctx tunnel up`), ctx calls `aws ssm describe-instance-information` to verify the target instance is registered in SSM before any connection attempt. If it is not, you will see a clear error:
+
+```
+instance "i-0abc123def456789a" is not registered in SSM — verify the SSM Agent
+is running and the instance profile has AmazonSSMManagedInstanceCore
+```
+
+### Mixed Context Example
+
+SSH and AWS tunnels coexist in the same `tunnels:` list:
+
+```yaml
+name: myproject-prod
+environment: production
+
+aws:
+  profile: myproject-prod
+  region: eu-west-1
+
+# Legacy SSH bastion for a separate service
+ssh:
+  bastion:
+    host: legacy-bastion.example.com
+    user: deploy
+    identity_file: ~/.ssh/deploy_key
+
+tunnels:
+  - name: postgres
+    type: aws
+    target: i-0abc123def456789a
+    remote_host: db.internal.vpc
+    remote_port: 5432
+    local_port: 5432
+    auto_connect: true
+
+  - name: legacy-api
+    remote_host: api.internal
+    remote_port: 8080
+    local_port: 8080
+```

--- a/examples/aws-sso.yaml
+++ b/examples/aws-sso.yaml
@@ -10,6 +10,19 @@ aws:
   profile: acme-prod
   region: us-east-1
   sso_login: true                 # Auto-run 'aws sso login'
+  tunnels:
+    - name: postgres
+      ssm_target: i-0abc123def456789a   # EC2 instance ID acting as SSM bastion
+      remote_host: db.internal.vpc
+      remote_port: 5432
+      local_port: 5432
+      auto_connect: true                # Start tunnel automatically on 'ctx use'
+
+    - name: redis
+      ssm_target: i-0abc123def456789a
+      remote_host: cache.internal.vpc
+      remote_port: 6379
+      local_port: 6379
 
 kubernetes:
   context: arn:aws:eks:us-east-1:123456789:cluster/production

--- a/examples/aws-sso.yaml
+++ b/examples/aws-sso.yaml
@@ -11,6 +11,22 @@ aws:
   region: us-east-1
   sso_login: true                 # Auto-run 'aws sso login'
 
+tunnels:
+  - name: postgres
+    type: aws
+    target: i-0abc123def456789a   # EC2 instance ID acting as SSM bastion
+    remote_host: db.internal.vpc
+    remote_port: 5432
+    local_port: 5432
+    auto_connect: true            # Start tunnel automatically on 'ctx use'
+
+  - name: redis
+    type: aws
+    target: i-0abc123def456789a
+    remote_host: cache.internal.vpc
+    remote_port: 6379
+    local_port: 6379
+
 kubernetes:
   context: arn:aws:eks:us-east-1:123456789:cluster/production
   namespace: default

--- a/internal/cli/deactivate.go
+++ b/internal/cli/deactivate.go
@@ -166,7 +166,8 @@ func runDeactivate(cmd *cobra.Command, args []string) error {
 	}
 
 	// Stop tunnels if any are configured and enabled
-	if len(ctx.Tunnels) > 0 {
+	hasSSMTunnels := ctx.AWS != nil && len(ctx.AWS.Tunnels) > 0
+	if len(ctx.Tunnels) > 0 || hasSSMTunnels {
 		if deactivateCfg.StopTunnels {
 			yellow.Fprint(os.Stderr, "• ")
 			fmt.Fprint(os.Stderr, "Stopping tunnels... ")
@@ -253,6 +254,14 @@ func stopContextTunnels(stateDir, contextName string) (int, error) {
 			stoppedCount++
 		}
 		delete(state.TunnelPIDs, name)
+	}
+
+	for name, entry := range state.SSMTunnelPIDs {
+		if isProcessRunning(entry.PID) {
+			killSSMProcessGroup(entry.PID)
+			stoppedCount++
+		}
+		delete(state.SSMTunnelPIDs, name)
 	}
 
 	// Remove state file

--- a/internal/cli/deactivate.go
+++ b/internal/cli/deactivate.go
@@ -248,8 +248,12 @@ func stopContextTunnels(stateDir, contextName string) (int, error) {
 	// New format: per-tunnel PIDs
 	for name, entry := range state.TunnelPIDs {
 		if isProcessRunning(entry.PID) {
-			process, _ := os.FindProcess(entry.PID)
-			process.Signal(syscall.SIGTERM)
+			if entry.Config.Type == "aws" {
+				killSSMProcessGroup(entry.PID)
+			} else {
+				process, _ := os.FindProcess(entry.PID)
+				process.Signal(syscall.SIGTERM)
+			}
 			stoppedCount++
 		}
 		delete(state.TunnelPIDs, name)

--- a/internal/cli/logout.go
+++ b/internal/cli/logout.go
@@ -76,7 +76,8 @@ func runLogout(cmd *cobra.Command, args []string) error {
 	}
 
 	// 2. Stop tunnels (always, ignore deactivate config for logout)
-	if len(ctx.Tunnels) > 0 {
+	hasSSMTunnels := ctx.AWS != nil && len(ctx.AWS.Tunnels) > 0
+	if len(ctx.Tunnels) > 0 || hasSSMTunnels {
 		yellow.Fprint(os.Stderr, "• ")
 		fmt.Fprint(os.Stderr, "Stopping tunnels... ")
 		stopped, err := stopContextTunnels(mgr.StateDir(), contextName)

--- a/internal/cli/tunnel.go
+++ b/internal/cli/tunnel.go
@@ -26,8 +26,8 @@ var tunnelBackground bool
 func newTunnelCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tunnel",
-		Short: "Manage SSH tunnels",
-		Long:  "Manage SSH tunnels for the current context.",
+		Short: "Manage tunnels",
+		Long:  "Manage SSH and SSM tunnels for the current context.",
 	}
 
 	cmd.AddCommand(newTunnelListCmd())
@@ -97,7 +97,11 @@ func runTunnelList(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to load context '%s': %w", currentContext, err)
 	}
 
-	if len(ctx.Tunnels) == 0 {
+	ssmTunnels := 0
+	if ctx.AWS != nil {
+		ssmTunnels = len(ctx.AWS.Tunnels)
+	}
+	if len(ctx.Tunnels) == 0 && ssmTunnels == 0 {
 		fmt.Printf("No tunnels defined for context '%s'.\n", ctx.Name)
 		return nil
 	}
@@ -105,7 +109,7 @@ func runTunnelList(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Tunnels for context '%s':\n\n", ctx.Name)
 
 	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"NAME", "LOCAL", "REMOTE", "DESCRIPTION"})
+	table.SetHeader([]string{"NAME", "TYPE", "LOCAL", "REMOTE", "DESCRIPTION"})
 	table.SetBorder(false)
 	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
@@ -119,7 +123,14 @@ func runTunnelList(cmd *cobra.Command, args []string) error {
 	for _, t := range ctx.Tunnels {
 		local := fmt.Sprintf("localhost:%d", t.LocalPort)
 		remote := fmt.Sprintf("%s:%d", t.RemoteHost, t.RemotePort)
-		table.Append([]string{t.Name, local, remote, t.Description})
+		table.Append([]string{t.Name, "ssh", local, remote, t.Description})
+	}
+	if ctx.AWS != nil {
+		for _, t := range ctx.AWS.Tunnels {
+			local := fmt.Sprintf("localhost:%d", t.LocalPort)
+			remote := fmt.Sprintf("%s:%d", t.RemoteHost, t.RemotePort)
+			table.Append([]string{t.Name, "ssm", local, remote, t.Description})
+		}
 	}
 
 	table.Render()
@@ -143,31 +154,38 @@ func runTunnelUp(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to load context '%s': %w", currentContext, err)
 	}
 
-	if ctx.SSH == nil || ctx.SSH.Bastion.Host == "" {
-		return fmt.Errorf("no SSH bastion configured for this context")
-	}
+	// Build candidate lists from both SSH and SSM tunnels
+	var sshTunnelsToStart []config.TunnelConfig
+	var ssmTunnelsToStart []config.SSMTunnelConfig
 
-	if len(ctx.Tunnels) == 0 {
-		return fmt.Errorf("no tunnels defined for this context")
-	}
-
-	// Determine which tunnels to start
-	var tunnelsToStart []config.TunnelConfig
 	if len(args) > 0 {
-		// Start specific tunnel
 		tunnelName := args[0]
 		for _, t := range ctx.Tunnels {
 			if t.Name == tunnelName {
-				tunnelsToStart = append(tunnelsToStart, t)
+				sshTunnelsToStart = append(sshTunnelsToStart, t)
 				break
 			}
 		}
-		if len(tunnelsToStart) == 0 {
+		if ctx.AWS != nil {
+			for _, t := range ctx.AWS.Tunnels {
+				if t.Name == tunnelName {
+					ssmTunnelsToStart = append(ssmTunnelsToStart, t)
+					break
+				}
+			}
+		}
+		if len(sshTunnelsToStart) == 0 && len(ssmTunnelsToStart) == 0 {
 			return fmt.Errorf("tunnel '%s' not found in context", tunnelName)
 		}
 	} else {
-		// Start all tunnels
-		tunnelsToStart = ctx.Tunnels
+		sshTunnelsToStart = ctx.Tunnels
+		if ctx.AWS != nil {
+			ssmTunnelsToStart = ctx.AWS.Tunnels
+		}
+	}
+
+	if len(sshTunnelsToStart) == 0 && len(ssmTunnelsToStart) == 0 {
+		return fmt.Errorf("no tunnels defined for this context")
 	}
 
 	// Get state directory
@@ -181,18 +199,21 @@ func runTunnelUp(cmd *cobra.Command, args []string) error {
 	state, _ := loadTunnelState(stateFile)
 	if state == nil {
 		state = &tunnelState{
-			ContextName: ctx.Name,
-			TunnelPIDs:  make(map[string]tunnelEntry),
+			ContextName:   ctx.Name,
+			TunnelPIDs:    make(map[string]tunnelEntry),
+			SSMTunnelPIDs: make(map[string]ssmTunnelEntry),
 		}
 	}
 	if state.TunnelPIDs == nil {
 		state.TunnelPIDs = make(map[string]tunnelEntry)
 	}
+	if state.SSMTunnelPIDs == nil {
+		state.SSMTunnelPIDs = make(map[string]ssmTunnelEntry)
+	}
 
 	// Migrate old state format if needed
 	if state.PID > 0 && len(state.TunnelPIDs) == 0 {
 		if isProcessRunning(state.PID) {
-			// Old format with single PID - kill it first
 			if proc, err := os.FindProcess(state.PID); err == nil {
 				proc.Signal(syscall.SIGTERM)
 				time.Sleep(200 * time.Millisecond)
@@ -204,97 +225,181 @@ func runTunnelUp(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("Starting tunnels for %s...\n", ctx.Name)
 
-	// Get tunnel timeout (default 5 seconds)
 	tunnelTimeout := 5
-	if ctx.SSH.TunnelTimeout > 0 {
+	if ctx.SSH != nil && ctx.SSH.TunnelTimeout > 0 {
 		tunnelTimeout = ctx.SSH.TunnelTimeout
 	}
 
-	// Start each tunnel as a separate SSH process
 	green := color.New(color.FgGreen)
 	yellow := color.New(color.FgYellow)
 	startedCount := 0
 	var startedTunnels []string
 
-	for _, t := range tunnelsToStart {
-		// Check if this tunnel is already running
-		if entry, exists := state.TunnelPIDs[t.Name]; exists {
-			if isProcessRunning(entry.PID) {
-				yellow.Printf("• %s already running (PID: %d)\n", t.Name, entry.PID)
-				continue
-			}
-			// Clean up stale entry
-			delete(state.TunnelPIDs, t.Name)
-		}
-
-		// Find available port (in case configured port is in use)
-		actualPort, portChanged := findAvailablePort(t.LocalPort)
-		tunnelConfig := t
-		tunnelConfig.LocalPort = actualPort
-
-		// Build SSH args for this single tunnel
-		sshArgs := buildSSHArgs(ctx.SSH, []config.TunnelConfig{tunnelConfig})
-
-		// Start SSH process in background
-		sshCmd := exec.Command("ssh", sshArgs...)
-		sshCmd.SysProcAttr = &syscall.SysProcAttr{
-			Setsid: true,
-		}
-
-		// Redirect output to log file
-		logFile := filepath.Join(stateDir, fmt.Sprintf("%s-%s.log", ctx.Name, t.Name))
-		logFd, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
-		if err != nil {
-			yellow.Printf("⚠ %s: failed to create log file: %v\n", t.Name, err)
-			continue
-		}
-		sshCmd.Stdout = logFd
-		sshCmd.Stderr = logFd
-
-		if err := sshCmd.Start(); err != nil {
-			logFd.Close()
-			yellow.Printf("⚠ %s: failed to start: %v\n", t.Name, err)
-			continue
-		}
-
-		// Wait to see if SSH exits early (auth failure) or stays running (connected)
-		exitCh := make(chan error, 1)
-		go func() {
-			exitCh <- sshCmd.Wait()
-		}()
-
-		// Wait for tunnel to connect or fail
-		select {
-		case <-exitCh:
-			// Process exited - connection failed
-			logFd.Close()
-			logContent, _ := os.ReadFile(logFile)
-			// Extract first line of error for cleaner output
-			errMsg := strings.TrimSpace(string(logContent))
-			if idx := strings.Index(errMsg, "\n"); idx > 0 {
-				errMsg = errMsg[:idx]
-			}
-			yellow.Printf("⚠ Tunnel %s: %s\n", t.Name, errMsg)
-			continue
-		case <-time.After(time.Duration(tunnelTimeout) * time.Second):
-			// Process still running - connected successfully
-		}
-
-		// Save to state
-		state.TunnelPIDs[t.Name] = tunnelEntry{
-			PID:       sshCmd.Process.Pid,
-			StartedAt: time.Now(),
-			Config:    tunnelConfig,
-		}
-		startedCount++
-		startedTunnels = append(startedTunnels, t.Name)
-
-		green.Print("✓ ")
-		if portChanged {
-			fmt.Printf("%-12s localhost:%d → %s:%d (PID: %d) ", t.Name, actualPort, t.RemoteHost, t.RemotePort, sshCmd.Process.Pid)
-			yellow.Printf("(port %d was in use)\n", t.LocalPort)
+	// --- SSH tunnels ---
+	if len(sshTunnelsToStart) > 0 {
+		if ctx.SSH == nil || ctx.SSH.Bastion.Host == "" {
+			yellow.Printf("⚠ SSH tunnels skipped: no SSH bastion configured\n")
 		} else {
-			fmt.Printf("%-12s localhost:%d → %s:%d (PID: %d)\n", t.Name, t.LocalPort, t.RemoteHost, t.RemotePort, sshCmd.Process.Pid)
+			for _, t := range sshTunnelsToStart {
+				if entry, exists := state.TunnelPIDs[t.Name]; exists {
+					if isProcessRunning(entry.PID) {
+						yellow.Printf("• %s already running (PID: %d)\n", t.Name, entry.PID)
+						continue
+					}
+					delete(state.TunnelPIDs, t.Name)
+				}
+
+				actualPort, portChanged := findAvailablePort(t.LocalPort)
+				tunnelConfig := t
+				tunnelConfig.LocalPort = actualPort
+
+				sshArgs := buildSSHArgs(ctx.SSH, []config.TunnelConfig{tunnelConfig})
+				sshCmd := exec.Command("ssh", sshArgs...)
+				sshCmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+
+				logFile := filepath.Join(stateDir, fmt.Sprintf("%s-%s.log", ctx.Name, t.Name))
+				logFd, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+				if err != nil {
+					yellow.Printf("⚠ %s: failed to create log file: %v\n", t.Name, err)
+					continue
+				}
+				sshCmd.Stdout = logFd
+				sshCmd.Stderr = logFd
+
+				if err := sshCmd.Start(); err != nil {
+					logFd.Close()
+					yellow.Printf("⚠ %s: failed to start: %v\n", t.Name, err)
+					continue
+				}
+
+				exitCh := make(chan error, 1)
+				go func() {
+					exitCh <- sshCmd.Wait()
+				}()
+
+				select {
+				case <-exitCh:
+					logFd.Close()
+					logContent, _ := os.ReadFile(logFile)
+					errMsg := strings.TrimSpace(string(logContent))
+					if idx := strings.Index(errMsg, "\n"); idx > 0 {
+						errMsg = errMsg[:idx]
+					}
+					yellow.Printf("⚠ Tunnel %s: %s\n", t.Name, errMsg)
+					continue
+				case <-time.After(time.Duration(tunnelTimeout) * time.Second):
+				}
+
+				state.TunnelPIDs[t.Name] = tunnelEntry{
+					PID:       sshCmd.Process.Pid,
+					StartedAt: time.Now(),
+					Config:    tunnelConfig,
+				}
+				startedCount++
+				startedTunnels = append(startedTunnels, t.Name)
+
+				green.Print("✓ ")
+				if portChanged {
+					fmt.Printf("%-12s localhost:%d → %s:%d (PID: %d) ", t.Name, actualPort, t.RemoteHost, t.RemotePort, sshCmd.Process.Pid)
+					yellow.Printf("(port %d was in use)\n", t.LocalPort)
+				} else {
+					fmt.Printf("%-12s localhost:%d → %s:%d (PID: %d)\n", t.Name, t.LocalPort, t.RemoteHost, t.RemotePort, sshCmd.Process.Pid)
+				}
+			}
+		}
+	}
+
+	// --- SSM tunnels ---
+	if len(ssmTunnelsToStart) > 0 {
+		if err := checkSSMDependencies(); err != nil {
+			yellow.Printf("⚠ SSM tunnels skipped: %v\n", err)
+		} else {
+			var awsCreds *config.AWSCredentials
+			if ctx.AWS.UseVault {
+				awsCreds = mgr.LoadAWSCredentials(ctx.Name)
+			}
+			awsEnv := buildAWSEnv(ctx.AWS, awsCreds)
+
+			for _, t := range ssmTunnelsToStart {
+				if entry, exists := state.SSMTunnelPIDs[t.Name]; exists {
+					if isProcessRunning(entry.PID) {
+						configChanged := entry.Config.SSMTarget != t.SSMTarget ||
+							entry.Config.RemoteHost != t.RemoteHost ||
+							entry.Config.RemotePort != t.RemotePort ||
+							entry.Config.LocalPort != t.LocalPort
+						if !configChanged {
+							yellow.Printf("• %s already running (PID: %d)\n", t.Name, entry.PID)
+							continue
+						}
+						// Config changed — stop the stale tunnel before restarting
+						killSSMProcessGroup(entry.PID)
+					}
+					delete(state.SSMTunnelPIDs, t.Name)
+				}
+
+				actualPort, portChanged := findAvailablePort(t.LocalPort)
+				tunnelConfig := t
+				tunnelConfig.LocalPort = actualPort
+
+				if err := validateSSMTarget(tunnelConfig.SSMTarget, awsEnv); err != nil {
+					yellow.Printf("⚠ %s: %v\n", t.Name, err)
+					continue
+				}
+
+				ssmArgs := buildSSMArgs(tunnelConfig)
+				ssmCmd := exec.Command("aws", ssmArgs...)
+				ssmCmd.Env = awsEnv
+				ssmCmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+
+				logFile := filepath.Join(stateDir, fmt.Sprintf("%s-%s.log", ctx.Name, t.Name))
+				logFd, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+				if err != nil {
+					yellow.Printf("⚠ %s: failed to create log file: %v\n", t.Name, err)
+					continue
+				}
+				ssmCmd.Stdout = logFd
+				ssmCmd.Stderr = logFd
+
+				if err := ssmCmd.Start(); err != nil {
+					logFd.Close()
+					yellow.Printf("⚠ %s: failed to start: %v\n", t.Name, err)
+					continue
+				}
+
+				exitCh := make(chan error, 1)
+				go func() {
+					exitCh <- ssmCmd.Wait()
+				}()
+
+				select {
+				case <-exitCh:
+					logFd.Close()
+					logContent, _ := os.ReadFile(logFile)
+					errMsg := strings.TrimSpace(string(logContent))
+					if idx := strings.Index(errMsg, "\n"); idx > 0 {
+						errMsg = errMsg[:idx]
+					}
+					yellow.Printf("⚠ Tunnel %s: %s\n", t.Name, errMsg)
+					continue
+				case <-time.After(time.Duration(tunnelTimeout) * time.Second):
+				}
+
+				state.SSMTunnelPIDs[t.Name] = ssmTunnelEntry{
+					PID:       ssmCmd.Process.Pid,
+					StartedAt: time.Now(),
+					Config:    tunnelConfig,
+				}
+				startedCount++
+				startedTunnels = append(startedTunnels, t.Name)
+
+				green.Print("✓ ")
+				if portChanged {
+					fmt.Printf("%-12s localhost:%d → %s:%d (PID: %d) ", t.Name, actualPort, t.RemoteHost, t.RemotePort, ssmCmd.Process.Pid)
+					yellow.Printf("(port %d was in use)\n", t.LocalPort)
+				} else {
+					fmt.Printf("%-12s localhost:%d → %s:%d (PID: %d)\n", t.Name, t.LocalPort, t.RemoteHost, t.RemotePort, ssmCmd.Process.Pid)
+				}
+			}
 		}
 	}
 
@@ -305,7 +410,6 @@ func runTunnelUp(cmd *cobra.Command, args []string) error {
 
 	if startedCount > 0 {
 		fmt.Printf("\n%d tunnel(s) started.\n", startedCount)
-		// Send tunnel.up audit event
 		sendTunnelEvent(mgr, ctx.Name, string(ctx.Environment), "tunnel.up", startedTunnels, true)
 	}
 	fmt.Println("Use 'ctx tunnel status' to check status.")
@@ -360,21 +464,99 @@ func buildSSHArgs(sshConfig *config.SSHConfig, tunnels []config.TunnelConfig) []
 	return args
 }
 
+// checkSSMDependencies verifies that aws CLI and session-manager-plugin are available.
+func checkSSMDependencies() error {
+	if _, err := exec.LookPath("aws"); err != nil {
+		return fmt.Errorf("AWS CLI not found: install aws-cli v2 from https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html")
+	}
+	if _, err := exec.LookPath("session-manager-plugin"); err != nil {
+		return fmt.Errorf("session-manager-plugin not found: install from https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html")
+	}
+	return nil
+}
+
+// buildAWSEnv builds a cmd.Env slice with AWS credentials injected explicitly.
+// This is required for auto_connect tunnels started before the shell hook sources the env file.
+func buildAWSEnv(awsCfg *config.AWSConfig, awsCreds *config.AWSCredentials) []string {
+	env := os.Environ()
+	if awsCfg.Config != "" {
+		env = append(env, "AWS_CONFIG_FILE="+expandPath(awsCfg.Config))
+	}
+	if awsCreds != nil {
+		env = append(env, "AWS_ACCESS_KEY_ID="+awsCreds.AccessKeyID)
+		env = append(env, "AWS_SECRET_ACCESS_KEY="+awsCreds.SecretAccessKey)
+		if awsCreds.SessionToken != "" {
+			env = append(env, "AWS_SESSION_TOKEN="+awsCreds.SessionToken)
+		}
+	} else if awsCfg.Profile != "" {
+		env = append(env, "AWS_PROFILE="+awsCfg.Profile)
+	}
+	if awsCfg.Region != "" {
+		env = append(env, "AWS_REGION="+awsCfg.Region, "AWS_DEFAULT_REGION="+awsCfg.Region)
+	}
+	return env
+}
+
+// buildSSMArgs builds the aws ssm start-session arguments for port forwarding to a remote host.
+func buildSSMArgs(tunnel config.SSMTunnelConfig) []string {
+	params := fmt.Sprintf(
+		`{"host":["%s"],"portNumber":["%d"],"localPortNumber":["%d"]}`,
+		tunnel.RemoteHost, tunnel.RemotePort, tunnel.LocalPort,
+	)
+	return []string{
+		"ssm", "start-session",
+		"--target", tunnel.SSMTarget,
+		"--document-name", "AWS-StartPortForwardingSessionToRemoteHost",
+		"--parameters", params,
+	}
+}
+
+// validateSSMTarget checks that the given EC2 instance ID is registered in SSM.
+func validateSSMTarget(instanceID string, awsEnv []string) error {
+	cmd := exec.Command("aws", "ssm", "describe-instance-information",
+		"--filters", fmt.Sprintf("Key=InstanceIds,Values=%s", instanceID),
+		"--output", "json",
+	)
+	cmd.Env = awsEnv
+	out, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to check SSM registration for %s: %w", instanceID, err)
+	}
+	var result struct {
+		InstanceInformationList []struct{} `json:"InstanceInformationList"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		return fmt.Errorf("failed to parse SSM response: %w", err)
+	}
+	if len(result.InstanceInformationList) == 0 {
+		return fmt.Errorf("instance %q is not registered in SSM — verify the SSM Agent is running and the instance profile has AmazonSSMManagedInstanceCore", instanceID)
+	}
+	return nil
+}
+
 // tunnelState represents the persisted state of running tunnels.
 // Now stores one PID per tunnel for independent management.
 type tunnelState struct {
-	StartedAt   time.Time              `json:"started_at"`            // Deprecated
-	TunnelPIDs  map[string]tunnelEntry `json:"tunnel_pids,omitempty"` // New: per-tunnel PIDs
-	ContextName string                 `json:"context_name"`
-	Tunnels     []config.TunnelConfig  `json:"tunnels,omitempty"` // Deprecated
-	PID         int                    `json:"pid,omitempty"`     // Deprecated: for backwards compat
+	StartedAt     time.Time                `json:"started_at"`              // Deprecated
+	TunnelPIDs    map[string]tunnelEntry   `json:"tunnel_pids,omitempty"`   // SSH tunnels
+	SSMTunnelPIDs map[string]ssmTunnelEntry `json:"ssm_tunnel_pids,omitempty"` // SSM tunnels
+	ContextName   string                   `json:"context_name"`
+	Tunnels       []config.TunnelConfig    `json:"tunnels,omitempty"` // Deprecated
+	PID           int                      `json:"pid,omitempty"`     // Deprecated: for backwards compat
 }
 
-// tunnelEntry represents a single running tunnel.
+// tunnelEntry represents a single running SSH tunnel.
 type tunnelEntry struct {
 	StartedAt time.Time           `json:"started_at"`
 	Config    config.TunnelConfig `json:"config"`
 	PID       int                 `json:"pid"`
+}
+
+// ssmTunnelEntry represents a single running SSM tunnel.
+type ssmTunnelEntry struct {
+	StartedAt time.Time              `json:"started_at"`
+	Config    config.SSMTunnelConfig `json:"config"`
+	PID       int                    `json:"pid"`
 }
 
 func loadTunnelState(path string) (*tunnelState, error) {
@@ -407,6 +589,14 @@ func isProcessRunning(pid int) bool {
 	}
 	err = process.Signal(syscall.Signal(0))
 	return err == nil
+}
+
+// killSSMProcessGroup sends SIGTERM to the entire process group of an SSM tunnel.
+// aws ssm start-session spawns session-manager-plugin as a child — killing only
+// the aws PID leaves the plugin alive. Since we start with Setsid=true the
+// process group ID equals the aws PID, so Kill(-pid) reaches both.
+func killSSMProcessGroup(pid int) {
+	_ = syscall.Kill(-pid, syscall.SIGTERM)
 }
 
 // isPortAvailable checks if a local port is available for binding.
@@ -477,31 +667,38 @@ func runTunnelDown(cmd *cobra.Command, args []string) error {
 	}
 
 	// New format: per-tunnel PIDs
-	if len(state.TunnelPIDs) == 0 {
+	if len(state.TunnelPIDs) == 0 && len(state.SSMTunnelPIDs) == 0 {
 		fmt.Println("No active tunnels found for this context.")
 		os.Remove(stateFile)
 		return nil
 	}
 
 	// Determine which tunnels to stop
-	var tunnelsToStop []string
+	var sshToStop []string
+	var ssmToStop []string
+
 	if len(args) > 0 {
-		// Stop specific tunnel
 		tunnelName := args[0]
 		if _, exists := state.TunnelPIDs[tunnelName]; exists {
-			tunnelsToStop = append(tunnelsToStop, tunnelName)
+			sshToStop = append(sshToStop, tunnelName)
+		} else if _, exists := state.SSMTunnelPIDs[tunnelName]; exists {
+			ssmToStop = append(ssmToStop, tunnelName)
 		} else {
 			return fmt.Errorf("tunnel '%s' is not running", tunnelName)
 		}
 	} else {
-		// Stop all tunnels
 		for name := range state.TunnelPIDs {
-			tunnelsToStop = append(tunnelsToStop, name)
+			sshToStop = append(sshToStop, name)
+		}
+		for name := range state.SSMTunnelPIDs {
+			ssmToStop = append(ssmToStop, name)
 		}
 	}
 
 	stoppedCount := 0
-	for _, name := range tunnelsToStop {
+	var stoppedNames []string
+
+	for _, name := range sshToStop {
 		entry := state.TunnelPIDs[name]
 		if isProcessRunning(entry.PID) {
 			process, _ := os.FindProcess(entry.PID)
@@ -510,10 +707,21 @@ func runTunnelDown(cmd *cobra.Command, args []string) error {
 			green.Printf("✓ Stopped %s (PID: %d)\n", name, entry.PID)
 		}
 		delete(state.TunnelPIDs, name)
+		stoppedNames = append(stoppedNames, name)
+	}
+	for _, name := range ssmToStop {
+		entry := state.SSMTunnelPIDs[name]
+		if isProcessRunning(entry.PID) {
+			killSSMProcessGroup(entry.PID)
+			stoppedCount++
+			green.Printf("✓ Stopped %s (PID: %d)\n", name, entry.PID)
+		}
+		delete(state.SSMTunnelPIDs, name)
+		stoppedNames = append(stoppedNames, name)
 	}
 
 	// Save or remove state file
-	if len(state.TunnelPIDs) == 0 {
+	if len(state.TunnelPIDs) == 0 && len(state.SSMTunnelPIDs) == 0 {
 		os.Remove(stateFile)
 	} else {
 		saveTunnelState(stateFile, state)
@@ -523,16 +731,26 @@ func runTunnelDown(cmd *cobra.Command, args []string) error {
 		fmt.Println("No active tunnels to stop.")
 	} else {
 		fmt.Printf("\n%d tunnel(s) stopped.\n", stoppedCount)
-		// Send tunnel.down audit event
-		sendTunnelEvent(mgr, ctx.Name, string(ctx.Environment), "tunnel.down", tunnelsToStop, true)
+		sendTunnelEvent(mgr, ctx.Name, string(ctx.Environment), "tunnel.down", stoppedNames, true)
 	}
 
 	return nil
 }
 
-// pendingTunnel holds information about a tunnel being started.
+// pendingTunnel holds information about an SSH tunnel being started.
 type pendingTunnel struct {
 	config      config.TunnelConfig
+	actualPort  int
+	portChanged bool
+	cmd         *exec.Cmd
+	logFile     string
+	logFd       *os.File
+	exitCh      chan error
+}
+
+// ssmPendingTunnel holds information about an SSM tunnel being started.
+type ssmPendingTunnel struct {
+	config      config.SSMTunnelConfig
 	actualPort  int
 	portChanged bool
 	cmd         *exec.Cmd
@@ -544,15 +762,25 @@ type pendingTunnel struct {
 // startAutoConnectTunnels starts tunnels that have auto_connect enabled.
 // Called during context switch. Returns (successfulTunnels, failedTunnels, error).
 func startAutoConnectTunnels(mgr *config.Manager, ctx *config.ContextConfig) ([]string, []string, error) {
-	// Filter tunnels with auto_connect
-	var autoConnectTunnels []config.TunnelConfig
+	// Filter SSH tunnels with auto_connect
+	var autoConnectSSH []config.TunnelConfig
 	for _, t := range ctx.Tunnels {
 		if t.AutoConnect {
-			autoConnectTunnels = append(autoConnectTunnels, t)
+			autoConnectSSH = append(autoConnectSSH, t)
 		}
 	}
 
-	if len(autoConnectTunnels) == 0 {
+	// Filter SSM tunnels with auto_connect
+	var autoConnectSSM []config.SSMTunnelConfig
+	if ctx.AWS != nil {
+		for _, t := range ctx.AWS.Tunnels {
+			if t.AutoConnect {
+				autoConnectSSM = append(autoConnectSSM, t)
+			}
+		}
+	}
+
+	if len(autoConnectSSH) == 0 && len(autoConnectSSM) == 0 {
 		return nil, nil, nil
 	}
 
@@ -567,120 +795,220 @@ func startAutoConnectTunnels(mgr *config.Manager, ctx *config.ContextConfig) ([]
 	state, _ := loadTunnelState(stateFile)
 	if state == nil {
 		state = &tunnelState{
-			ContextName: ctx.Name,
-			TunnelPIDs:  make(map[string]tunnelEntry),
+			ContextName:   ctx.Name,
+			TunnelPIDs:    make(map[string]tunnelEntry),
+			SSMTunnelPIDs: make(map[string]ssmTunnelEntry),
 		}
 	}
 	if state.TunnelPIDs == nil {
 		state.TunnelPIDs = make(map[string]tunnelEntry)
 	}
+	if state.SSMTunnelPIDs == nil {
+		state.SSMTunnelPIDs = make(map[string]ssmTunnelEntry)
+	}
 
 	yellow := color.New(color.FgYellow)
 	green := color.New(color.FgGreen)
 
-	// Phase 1: Start all tunnels in parallel
-	var pending []pendingTunnel
-	for _, t := range autoConnectTunnels {
-		// Check if this tunnel is already running
-		if entry, exists := state.TunnelPIDs[t.Name]; exists {
-			if isProcessRunning(entry.PID) {
-				green.Fprintf(os.Stderr, "✓ Tunnel %s already running (PID: %d)\n", t.Name, entry.PID)
-				continue
-			}
-			delete(state.TunnelPIDs, t.Name)
-		}
-
-		// Find available port (in case configured port is in use)
-		actualPort, portChanged := findAvailablePort(t.LocalPort)
-		tunnelConfig := t
-		tunnelConfig.LocalPort = actualPort
-
-		// Build SSH args for this single tunnel
-		sshArgs := buildSSHArgs(ctx.SSH, []config.TunnelConfig{tunnelConfig})
-
-		// Start SSH process in background
-		sshCmd := exec.Command("ssh", sshArgs...)
-		sshCmd.SysProcAttr = &syscall.SysProcAttr{
-			Setsid: true,
-		}
-
-		// Redirect output to log file
-		logFile := filepath.Join(stateDir, fmt.Sprintf("%s-%s.log", ctx.Name, t.Name))
-		logFd, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
-		if err != nil {
-			yellow.Fprintf(os.Stderr, "⚠ Tunnel %s: failed to create log file: %v\n", t.Name, err)
-			continue
-		}
-		sshCmd.Stdout = logFd
-		sshCmd.Stderr = logFd
-
-		if err := sshCmd.Start(); err != nil {
-			logFd.Close()
-			yellow.Fprintf(os.Stderr, "⚠ Tunnel %s: failed to start: %v\n", t.Name, err)
-			continue
-		}
-
-		// Start goroutine to wait for process exit
-		exitCh := make(chan error, 1)
-		go func(cmd *exec.Cmd) {
-			exitCh <- cmd.Wait()
-		}(sshCmd)
-
-		pending = append(pending, pendingTunnel{
-			config:      tunnelConfig,
-			actualPort:  actualPort,
-			portChanged: portChanged,
-			cmd:         sshCmd,
-			logFile:     logFile,
-			logFd:       logFd,
-			exitCh:      exitCh,
-		})
-	}
-
-	if len(pending) == 0 {
-		return nil, nil, nil
-	}
-
-	// Phase 2: Wait for tunnels to either connect or fail
-	// SSH auth failures typically complete within 2-3 seconds
-	timeout := 5 // default 5 seconds
+	timeout := 5
 	if ctx.SSH != nil && ctx.SSH.TunnelTimeout > 0 {
 		timeout = ctx.SSH.TunnelTimeout
 	}
-	time.Sleep(time.Duration(timeout) * time.Second)
 
-	// Phase 3: Check results and report
 	var startedTunnels []string
 	var failedTunnels []string
-	for _, p := range pending {
-		t := p.config
 
-		// Check if process exited (failed) or still running (connected)
-		select {
-		case <-p.exitCh:
-			// Process exited - connection failed
-			p.logFd.Close()
-			logContent, _ := os.ReadFile(p.logFile)
-			errMsg := strings.TrimSpace(string(logContent))
-			if idx := strings.Index(errMsg, "\n"); idx > 0 {
-				errMsg = errMsg[:idx]
+	// --- SSH auto-connect tunnels ---
+	if len(autoConnectSSH) > 0 && ctx.SSH != nil && ctx.SSH.Bastion.Host != "" {
+		// Phase 1: Start all SSH tunnels in parallel
+		var pending []pendingTunnel
+		for _, t := range autoConnectSSH {
+			if entry, exists := state.TunnelPIDs[t.Name]; exists {
+				if isProcessRunning(entry.PID) {
+					green.Fprintf(os.Stderr, "✓ Tunnel %s already running (PID: %d)\n", t.Name, entry.PID)
+					continue
+				}
+				delete(state.TunnelPIDs, t.Name)
 			}
-			yellow.Fprintf(os.Stderr, "⚠ Tunnel %s: %s\n", t.Name, errMsg)
-			failedTunnels = append(failedTunnels, t.Name)
-		default:
-			// Process still running - connected successfully
-			state.TunnelPIDs[t.Name] = tunnelEntry{
-				PID:       p.cmd.Process.Pid,
-				StartedAt: time.Now(),
-				Config:    t,
-			}
-			startedTunnels = append(startedTunnels, t.Name)
 
-			if p.portChanged {
-				green.Fprintf(os.Stderr, "✓ Tunnel %s: localhost:%d → %s:%d ", t.Name, p.actualPort, t.RemoteHost, t.RemotePort)
-				yellow.Fprintf(os.Stderr, "(port %d in use)\n", t.LocalPort)
-			} else {
-				green.Fprintf(os.Stderr, "✓ Tunnel %s: localhost:%d → %s:%d\n", t.Name, t.LocalPort, t.RemoteHost, t.RemotePort)
+			actualPort, portChanged := findAvailablePort(t.LocalPort)
+			tunnelConfig := t
+			tunnelConfig.LocalPort = actualPort
+
+			sshArgs := buildSSHArgs(ctx.SSH, []config.TunnelConfig{tunnelConfig})
+			sshCmd := exec.Command("ssh", sshArgs...)
+			sshCmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+
+			logFile := filepath.Join(stateDir, fmt.Sprintf("%s-%s.log", ctx.Name, t.Name))
+			logFd, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+			if err != nil {
+				yellow.Fprintf(os.Stderr, "⚠ Tunnel %s: failed to create log file: %v\n", t.Name, err)
+				continue
+			}
+			sshCmd.Stdout = logFd
+			sshCmd.Stderr = logFd
+
+			if err := sshCmd.Start(); err != nil {
+				logFd.Close()
+				yellow.Fprintf(os.Stderr, "⚠ Tunnel %s: failed to start: %v\n", t.Name, err)
+				continue
+			}
+
+			exitCh := make(chan error, 1)
+			go func(cmd *exec.Cmd) {
+				exitCh <- cmd.Wait()
+			}(sshCmd)
+
+			pending = append(pending, pendingTunnel{
+				config:      tunnelConfig,
+				actualPort:  actualPort,
+				portChanged: portChanged,
+				cmd:         sshCmd,
+				logFile:     logFile,
+				logFd:       logFd,
+				exitCh:      exitCh,
+			})
+		}
+
+		if len(pending) > 0 {
+			// Phase 2: Wait for tunnels to either connect or fail
+			time.Sleep(time.Duration(timeout) * time.Second)
+
+			// Phase 3: Check results
+			for _, p := range pending {
+				t := p.config
+				select {
+				case <-p.exitCh:
+					p.logFd.Close()
+					logContent, _ := os.ReadFile(p.logFile)
+					errMsg := strings.TrimSpace(string(logContent))
+					if idx := strings.Index(errMsg, "\n"); idx > 0 {
+						errMsg = errMsg[:idx]
+					}
+					yellow.Fprintf(os.Stderr, "⚠ Tunnel %s: %s\n", t.Name, errMsg)
+					failedTunnels = append(failedTunnels, t.Name)
+				default:
+					state.TunnelPIDs[t.Name] = tunnelEntry{
+						PID:       p.cmd.Process.Pid,
+						StartedAt: time.Now(),
+						Config:    t,
+					}
+					startedTunnels = append(startedTunnels, t.Name)
+
+					if p.portChanged {
+						green.Fprintf(os.Stderr, "✓ Tunnel %s: localhost:%d → %s:%d ", t.Name, p.actualPort, t.RemoteHost, t.RemotePort)
+						yellow.Fprintf(os.Stderr, "(port %d in use)\n", t.LocalPort)
+					} else {
+						green.Fprintf(os.Stderr, "✓ Tunnel %s: localhost:%d → %s:%d\n", t.Name, t.LocalPort, t.RemoteHost, t.RemotePort)
+					}
+				}
+			}
+		}
+	}
+
+	// --- SSM auto-connect tunnels ---
+	if len(autoConnectSSM) > 0 {
+		if err := checkSSMDependencies(); err != nil {
+			yellow.Fprintf(os.Stderr, "⚠ SSM auto-connect skipped: %v\n", err)
+		} else {
+			var awsCreds *config.AWSCredentials
+			if ctx.AWS.UseVault {
+				awsCreds = mgr.LoadAWSCredentials(ctx.Name)
+			}
+			awsEnv := buildAWSEnv(ctx.AWS, awsCreds)
+
+			// Phase 1: Start all SSM tunnels in parallel
+			var ssmPending []ssmPendingTunnel
+			for _, t := range autoConnectSSM {
+				if entry, exists := state.SSMTunnelPIDs[t.Name]; exists {
+					if isProcessRunning(entry.PID) {
+						configChanged := entry.Config.SSMTarget != t.SSMTarget ||
+							entry.Config.RemoteHost != t.RemoteHost ||
+							entry.Config.RemotePort != t.RemotePort ||
+							entry.Config.LocalPort != t.LocalPort
+						if !configChanged {
+							green.Fprintf(os.Stderr, "✓ Tunnel %s already running (PID: %d)\n", t.Name, entry.PID)
+							continue
+						}
+						killSSMProcessGroup(entry.PID)
+					}
+					delete(state.SSMTunnelPIDs, t.Name)
+				}
+
+				actualPort, portChanged := findAvailablePort(t.LocalPort)
+				tunnelConfig := t
+				tunnelConfig.LocalPort = actualPort
+
+				ssmArgs := buildSSMArgs(tunnelConfig)
+				ssmCmd := exec.Command("aws", ssmArgs...)
+				ssmCmd.Env = awsEnv
+				ssmCmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+
+				logFile := filepath.Join(stateDir, fmt.Sprintf("%s-%s.log", ctx.Name, t.Name))
+				logFd, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+				if err != nil {
+					yellow.Fprintf(os.Stderr, "⚠ Tunnel %s: failed to create log file: %v\n", t.Name, err)
+					continue
+				}
+				ssmCmd.Stdout = logFd
+				ssmCmd.Stderr = logFd
+
+				if err := ssmCmd.Start(); err != nil {
+					logFd.Close()
+					yellow.Fprintf(os.Stderr, "⚠ Tunnel %s: failed to start: %v\n", t.Name, err)
+					failedTunnels = append(failedTunnels, t.Name)
+					continue
+				}
+
+				exitCh := make(chan error, 1)
+				go func(cmd *exec.Cmd) {
+					exitCh <- cmd.Wait()
+				}(ssmCmd)
+
+				ssmPending = append(ssmPending, ssmPendingTunnel{
+					config:      tunnelConfig,
+					actualPort:  actualPort,
+					portChanged: portChanged,
+					cmd:         ssmCmd,
+					logFile:     logFile,
+					logFd:       logFd,
+					exitCh:      exitCh,
+				})
+			}
+
+			if len(ssmPending) > 0 {
+				// Phase 2: Wait once for all SSM tunnels
+				time.Sleep(time.Duration(timeout) * time.Second)
+
+				// Phase 3: Check results
+				for _, p := range ssmPending {
+					t := p.config
+					select {
+					case <-p.exitCh:
+						p.logFd.Close()
+						logContent, _ := os.ReadFile(p.logFile)
+						errMsg := strings.TrimSpace(string(logContent))
+						if idx := strings.Index(errMsg, "\n"); idx > 0 {
+							errMsg = errMsg[:idx]
+						}
+						yellow.Fprintf(os.Stderr, "⚠ Tunnel %s: %s\n", t.Name, errMsg)
+						failedTunnels = append(failedTunnels, t.Name)
+					default:
+						state.SSMTunnelPIDs[t.Name] = ssmTunnelEntry{
+							PID:       p.cmd.Process.Pid,
+							StartedAt: time.Now(),
+							Config:    t,
+						}
+						startedTunnels = append(startedTunnels, t.Name)
+
+						if p.portChanged {
+							green.Fprintf(os.Stderr, "✓ Tunnel %s: localhost:%d → %s:%d ", t.Name, p.actualPort, t.RemoteHost, t.RemotePort)
+							yellow.Fprintf(os.Stderr, "(port %d in use)\n", t.LocalPort)
+						} else {
+							green.Fprintf(os.Stderr, "✓ Tunnel %s: localhost:%d → %s:%d\n", t.Name, t.LocalPort, t.RemoteHost, t.RemotePort)
+						}
+					}
+				}
 			}
 		}
 	}
@@ -750,7 +1078,7 @@ func runTunnelStatus(cmd *cobra.Command, args []string) error {
 	}
 
 	// New format: per-tunnel PIDs
-	if len(state.TunnelPIDs) == 0 {
+	if len(state.TunnelPIDs) == 0 && len(state.SSMTunnelPIDs) == 0 {
 		fmt.Println("No active tunnels for this context.")
 		return nil
 	}
@@ -758,7 +1086,7 @@ func runTunnelStatus(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Tunnels for context '%s'\n\n", ctx.Name)
 
 	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"TUNNEL", "LOCAL", "REMOTE", "PID", "STATUS"})
+	table.SetHeader([]string{"TUNNEL", "TYPE", "LOCAL", "REMOTE", "PID", "STATUS"})
 	table.SetBorder(false)
 	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
@@ -769,8 +1097,8 @@ func runTunnelStatus(cmd *cobra.Command, args []string) error {
 	table.SetTablePadding("  ")
 	table.SetNoWhiteSpace(true)
 
-	activeCount := 0
-	staleNames := []string{}
+	var staleSSH, staleSSM []string
+
 	for name, entry := range state.TunnelPIDs {
 		t := entry.Config
 		localAddr := fmt.Sprintf("localhost:%d", t.LocalPort)
@@ -779,20 +1107,35 @@ func runTunnelStatus(cmd *cobra.Command, args []string) error {
 		var statusStr string
 		if isProcessRunning(entry.PID) {
 			statusStr = "● connected"
-			activeCount++
 		} else {
 			statusStr = "○ stopped"
-			staleNames = append(staleNames, name)
+			staleSSH = append(staleSSH, name)
 		}
-		table.Append([]string{name, localAddr, remoteAddr, pidStr, statusStr})
+		table.Append([]string{name, "ssh", localAddr, remoteAddr, pidStr, statusStr})
+	}
+	for name, entry := range state.SSMTunnelPIDs {
+		t := entry.Config
+		localAddr := fmt.Sprintf("localhost:%d", t.LocalPort)
+		remoteAddr := fmt.Sprintf("%s:%d", t.RemoteHost, t.RemotePort)
+		pidStr := fmt.Sprintf("%d", entry.PID)
+		var statusStr string
+		if isProcessRunning(entry.PID) {
+			statusStr = "● connected"
+		} else {
+			statusStr = "○ stopped"
+			staleSSM = append(staleSSM, name)
+		}
+		table.Append([]string{name, "ssm", localAddr, remoteAddr, pidStr, statusStr})
 	}
 
-	// Clean up stale entries
-	for _, name := range staleNames {
+	for _, name := range staleSSH {
 		delete(state.TunnelPIDs, name)
 	}
-	if len(staleNames) > 0 {
-		if len(state.TunnelPIDs) == 0 {
+	for _, name := range staleSSM {
+		delete(state.SSMTunnelPIDs, name)
+	}
+	if len(staleSSH) > 0 || len(staleSSM) > 0 {
+		if len(state.TunnelPIDs) == 0 && len(state.SSMTunnelPIDs) == 0 {
 			os.Remove(stateFile)
 		} else {
 			saveTunnelState(stateFile, state)
@@ -801,7 +1144,6 @@ func runTunnelStatus(cmd *cobra.Command, args []string) error {
 
 	table.Render()
 
-	// Show log file location
 	logFile := filepath.Join(stateDir, ctx.Name+".log")
 	fmt.Printf("\nLog file: %s\n", logFile)
 

--- a/internal/cli/tunnel.go
+++ b/internal/cli/tunnel.go
@@ -26,8 +26,8 @@ var tunnelBackground bool
 func newTunnelCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tunnel",
-		Short: "Manage SSH tunnels",
-		Long:  "Manage SSH tunnels for the current context.",
+		Short: "Manage tunnels",
+		Long:  "Manage SSH and AWS tunnels for the current context.",
 	}
 
 	cmd.AddCommand(newTunnelListCmd())
@@ -105,7 +105,7 @@ func runTunnelList(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Tunnels for context '%s':\n\n", ctx.Name)
 
 	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"NAME", "LOCAL", "REMOTE", "DESCRIPTION"})
+	table.SetHeader([]string{"NAME", "TYPE", "LOCAL", "REMOTE", "DESCRIPTION"})
 	table.SetBorder(false)
 	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
@@ -117,9 +117,13 @@ func runTunnelList(cmd *cobra.Command, args []string) error {
 	table.SetNoWhiteSpace(true)
 
 	for _, t := range ctx.Tunnels {
+		tunnelType := t.Type
+		if tunnelType == "" {
+			tunnelType = "ssh"
+		}
 		local := fmt.Sprintf("localhost:%d", t.LocalPort)
 		remote := fmt.Sprintf("%s:%d", t.RemoteHost, t.RemotePort)
-		table.Append([]string{t.Name, local, remote, t.Description})
+		table.Append([]string{t.Name, tunnelType, local, remote, t.Description})
 	}
 
 	table.Render()
@@ -143,18 +147,10 @@ func runTunnelUp(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to load context '%s': %w", currentContext, err)
 	}
 
-	if ctx.SSH == nil || ctx.SSH.Bastion.Host == "" {
-		return fmt.Errorf("no SSH bastion configured for this context")
-	}
-
-	if len(ctx.Tunnels) == 0 {
-		return fmt.Errorf("no tunnels defined for this context")
-	}
-
-	// Determine which tunnels to start
+	// Build candidate list
 	var tunnelsToStart []config.TunnelConfig
+
 	if len(args) > 0 {
-		// Start specific tunnel
 		tunnelName := args[0]
 		for _, t := range ctx.Tunnels {
 			if t.Name == tunnelName {
@@ -166,8 +162,11 @@ func runTunnelUp(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("tunnel '%s' not found in context", tunnelName)
 		}
 	} else {
-		// Start all tunnels
 		tunnelsToStart = ctx.Tunnels
+	}
+
+	if len(tunnelsToStart) == 0 {
+		return fmt.Errorf("no tunnels defined for this context")
 	}
 
 	// Get state directory
@@ -192,7 +191,6 @@ func runTunnelUp(cmd *cobra.Command, args []string) error {
 	// Migrate old state format if needed
 	if state.PID > 0 && len(state.TunnelPIDs) == 0 {
 		if isProcessRunning(state.PID) {
-			// Old format with single PID - kill it first
 			if proc, err := os.FindProcess(state.PID); err == nil {
 				proc.Signal(syscall.SIGTERM)
 				time.Sleep(200 * time.Millisecond)
@@ -204,97 +202,197 @@ func runTunnelUp(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("Starting tunnels for %s...\n", ctx.Name)
 
-	// Get tunnel timeout (default 5 seconds)
 	tunnelTimeout := 5
-	if ctx.SSH.TunnelTimeout > 0 {
+	if ctx.SSH != nil && ctx.SSH.TunnelTimeout > 0 {
 		tunnelTimeout = ctx.SSH.TunnelTimeout
 	}
 
-	// Start each tunnel as a separate SSH process
 	green := color.New(color.FgGreen)
 	yellow := color.New(color.FgYellow)
 	startedCount := 0
 	var startedTunnels []string
 
+	// Pre-flight checks — run once before the loop, not per-tunnel
+	sshOK := ctx.SSH != nil && ctx.SSH.Bastion.Host != ""
+	ssmOK := false
+	var awsEnv []string
+
+	hasSSH, hasAWS := false, false
 	for _, t := range tunnelsToStart {
-		// Check if this tunnel is already running
-		if entry, exists := state.TunnelPIDs[t.Name]; exists {
-			if isProcessRunning(entry.PID) {
-				yellow.Printf("• %s already running (PID: %d)\n", t.Name, entry.PID)
+		if t.Type == "aws" {
+			hasAWS = true
+		} else {
+			hasSSH = true
+		}
+	}
+
+	if hasSSH && !sshOK {
+		yellow.Printf("⚠ SSH tunnels skipped: no SSH bastion configured\n")
+	}
+	if hasAWS {
+		if ctx.AWS == nil {
+			yellow.Printf("⚠ AWS tunnels skipped: no aws config found\n")
+		} else if err := checkSSMDependencies(); err != nil {
+			yellow.Printf("⚠ AWS tunnels skipped: %v\n", err)
+		} else {
+			var awsCreds *config.AWSCredentials
+			if ctx.AWS.UseVault {
+				awsCreds = mgr.LoadAWSCredentials(ctx.Name)
+			}
+			awsEnv = buildAWSEnv(ctx.AWS, awsCreds)
+			ssmOK = true
+		}
+	}
+
+	for _, t := range tunnelsToStart {
+		if t.Type == "aws" {
+			if !ssmOK {
 				continue
 			}
-			// Clean up stale entry
-			delete(state.TunnelPIDs, t.Name)
-		}
 
-		// Find available port (in case configured port is in use)
-		actualPort, portChanged := findAvailablePort(t.LocalPort)
-		tunnelConfig := t
-		tunnelConfig.LocalPort = actualPort
-
-		// Build SSH args for this single tunnel
-		sshArgs := buildSSHArgs(ctx.SSH, []config.TunnelConfig{tunnelConfig})
-
-		// Start SSH process in background
-		sshCmd := exec.Command("ssh", sshArgs...)
-		sshCmd.SysProcAttr = &syscall.SysProcAttr{
-			Setsid: true,
-		}
-
-		// Redirect output to log file
-		logFile := filepath.Join(stateDir, fmt.Sprintf("%s-%s.log", ctx.Name, t.Name))
-		logFd, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
-		if err != nil {
-			yellow.Printf("⚠ %s: failed to create log file: %v\n", t.Name, err)
-			continue
-		}
-		sshCmd.Stdout = logFd
-		sshCmd.Stderr = logFd
-
-		if err := sshCmd.Start(); err != nil {
-			logFd.Close()
-			yellow.Printf("⚠ %s: failed to start: %v\n", t.Name, err)
-			continue
-		}
-
-		// Wait to see if SSH exits early (auth failure) or stays running (connected)
-		exitCh := make(chan error, 1)
-		go func() {
-			exitCh <- sshCmd.Wait()
-		}()
-
-		// Wait for tunnel to connect or fail
-		select {
-		case <-exitCh:
-			// Process exited - connection failed
-			logFd.Close()
-			logContent, _ := os.ReadFile(logFile)
-			// Extract first line of error for cleaner output
-			errMsg := strings.TrimSpace(string(logContent))
-			if idx := strings.Index(errMsg, "\n"); idx > 0 {
-				errMsg = errMsg[:idx]
+			if entry, exists := state.TunnelPIDs[t.Name]; exists {
+				if isProcessRunning(entry.PID) {
+					configChanged := entry.Config.Target != t.Target ||
+						entry.Config.RemoteHost != t.RemoteHost ||
+						entry.Config.RemotePort != t.RemotePort ||
+						entry.Config.LocalPort != t.LocalPort
+					if !configChanged {
+						yellow.Printf("• %s already running (PID: %d)\n", t.Name, entry.PID)
+						continue
+					}
+					// Config changed — stop the stale tunnel before restarting
+					killSSMProcessGroup(entry.PID)
+				}
+				delete(state.TunnelPIDs, t.Name)
 			}
-			yellow.Printf("⚠ Tunnel %s: %s\n", t.Name, errMsg)
-			continue
-		case <-time.After(time.Duration(tunnelTimeout) * time.Second):
-			// Process still running - connected successfully
-		}
 
-		// Save to state
-		state.TunnelPIDs[t.Name] = tunnelEntry{
-			PID:       sshCmd.Process.Pid,
-			StartedAt: time.Now(),
-			Config:    tunnelConfig,
-		}
-		startedCount++
-		startedTunnels = append(startedTunnels, t.Name)
+			actualPort, portChanged := findAvailablePort(t.LocalPort)
+			tunnelConfig := t
+			tunnelConfig.LocalPort = actualPort
 
-		green.Print("✓ ")
-		if portChanged {
-			fmt.Printf("%-12s localhost:%d → %s:%d (PID: %d) ", t.Name, actualPort, t.RemoteHost, t.RemotePort, sshCmd.Process.Pid)
-			yellow.Printf("(port %d was in use)\n", t.LocalPort)
+			if err := validateSSMTarget(tunnelConfig.Target, awsEnv); err != nil {
+				yellow.Printf("⚠ %s: %v\n", t.Name, err)
+				continue
+			}
+
+			ssmArgs := buildSSMArgs(tunnelConfig)
+			cmd := exec.Command("aws", ssmArgs...)
+			cmd.Env = awsEnv
+			cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+
+			logFile := filepath.Join(stateDir, fmt.Sprintf("%s-%s.log", ctx.Name, t.Name))
+			logFd, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+			if err != nil {
+				yellow.Printf("⚠ %s: failed to create log file: %v\n", t.Name, err)
+				continue
+			}
+			cmd.Stdout = logFd
+			cmd.Stderr = logFd
+
+			if err := cmd.Start(); err != nil {
+				logFd.Close()
+				yellow.Printf("⚠ %s: failed to start: %v\n", t.Name, err)
+				continue
+			}
+
+			exitCh := make(chan error, 1)
+			go func(c *exec.Cmd) { exitCh <- c.Wait() }(cmd)
+
+			select {
+			case <-exitCh:
+				logFd.Close()
+				logContent, _ := os.ReadFile(logFile)
+				errMsg := strings.TrimSpace(string(logContent))
+				if idx := strings.Index(errMsg, "\n"); idx > 0 {
+					errMsg = errMsg[:idx]
+				}
+				yellow.Printf("⚠ Tunnel %s: %s\n", t.Name, errMsg)
+				continue
+			case <-time.After(time.Duration(tunnelTimeout) * time.Second):
+			}
+
+			state.TunnelPIDs[t.Name] = tunnelEntry{
+				PID:       cmd.Process.Pid,
+				StartedAt: time.Now(),
+				Config:    tunnelConfig,
+			}
+			startedCount++
+			startedTunnels = append(startedTunnels, t.Name)
+
+			green.Print("✓ ")
+			if portChanged {
+				fmt.Printf("%-12s localhost:%d → %s:%d (PID: %d) ", t.Name, actualPort, t.RemoteHost, t.RemotePort, cmd.Process.Pid)
+				yellow.Printf("(port %d was in use)\n", t.LocalPort)
+			} else {
+				fmt.Printf("%-12s localhost:%d → %s:%d (PID: %d)\n", t.Name, t.LocalPort, t.RemoteHost, t.RemotePort, cmd.Process.Pid)
+			}
 		} else {
-			fmt.Printf("%-12s localhost:%d → %s:%d (PID: %d)\n", t.Name, t.LocalPort, t.RemoteHost, t.RemotePort, sshCmd.Process.Pid)
+			if !sshOK {
+				continue
+			}
+
+			if entry, exists := state.TunnelPIDs[t.Name]; exists {
+				if isProcessRunning(entry.PID) {
+					yellow.Printf("• %s already running (PID: %d)\n", t.Name, entry.PID)
+					continue
+				}
+				delete(state.TunnelPIDs, t.Name)
+			}
+
+			actualPort, portChanged := findAvailablePort(t.LocalPort)
+			tunnelConfig := t
+			tunnelConfig.LocalPort = actualPort
+
+			sshArgs := buildSSHArgs(ctx.SSH, []config.TunnelConfig{tunnelConfig})
+			cmd := exec.Command("ssh", sshArgs...)
+			cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+
+			logFile := filepath.Join(stateDir, fmt.Sprintf("%s-%s.log", ctx.Name, t.Name))
+			logFd, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+			if err != nil {
+				yellow.Printf("⚠ %s: failed to create log file: %v\n", t.Name, err)
+				continue
+			}
+			cmd.Stdout = logFd
+			cmd.Stderr = logFd
+
+			if err := cmd.Start(); err != nil {
+				logFd.Close()
+				yellow.Printf("⚠ %s: failed to start: %v\n", t.Name, err)
+				continue
+			}
+
+			exitCh := make(chan error, 1)
+			go func(c *exec.Cmd) { exitCh <- c.Wait() }(cmd)
+
+			select {
+			case <-exitCh:
+				logFd.Close()
+				logContent, _ := os.ReadFile(logFile)
+				errMsg := strings.TrimSpace(string(logContent))
+				if idx := strings.Index(errMsg, "\n"); idx > 0 {
+					errMsg = errMsg[:idx]
+				}
+				yellow.Printf("⚠ Tunnel %s: %s\n", t.Name, errMsg)
+				continue
+			case <-time.After(time.Duration(tunnelTimeout) * time.Second):
+			}
+
+			state.TunnelPIDs[t.Name] = tunnelEntry{
+				PID:       cmd.Process.Pid,
+				StartedAt: time.Now(),
+				Config:    tunnelConfig,
+			}
+			startedCount++
+			startedTunnels = append(startedTunnels, t.Name)
+
+			green.Print("✓ ")
+			if portChanged {
+				fmt.Printf("%-12s localhost:%d → %s:%d (PID: %d) ", t.Name, actualPort, t.RemoteHost, t.RemotePort, cmd.Process.Pid)
+				yellow.Printf("(port %d was in use)\n", t.LocalPort)
+			} else {
+				fmt.Printf("%-12s localhost:%d → %s:%d (PID: %d)\n", t.Name, t.LocalPort, t.RemoteHost, t.RemotePort, cmd.Process.Pid)
+			}
 		}
 	}
 
@@ -305,7 +403,6 @@ func runTunnelUp(cmd *cobra.Command, args []string) error {
 
 	if startedCount > 0 {
 		fmt.Printf("\n%d tunnel(s) started.\n", startedCount)
-		// Send tunnel.up audit event
 		sendTunnelEvent(mgr, ctx.Name, string(ctx.Environment), "tunnel.up", startedTunnels, true)
 	}
 	fmt.Println("Use 'ctx tunnel status' to check status.")
@@ -360,17 +457,87 @@ func buildSSHArgs(sshConfig *config.SSHConfig, tunnels []config.TunnelConfig) []
 	return args
 }
 
+// checkSSMDependencies verifies that aws CLI and session-manager-plugin are available.
+func checkSSMDependencies() error {
+	if _, err := exec.LookPath("aws"); err != nil {
+		return fmt.Errorf("AWS CLI not found: install aws-cli v2 from https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html")
+	}
+	if _, err := exec.LookPath("session-manager-plugin"); err != nil {
+		return fmt.Errorf("session-manager-plugin not found: install from https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html")
+	}
+	return nil
+}
+
+// buildAWSEnv builds a cmd.Env slice with AWS credentials injected explicitly.
+// This is required for auto_connect tunnels started before the shell hook sources the env file.
+func buildAWSEnv(awsCfg *config.AWSConfig, awsCreds *config.AWSCredentials) []string {
+	env := os.Environ()
+	if awsCfg.Config != "" {
+		env = append(env, "AWS_CONFIG_FILE="+expandPath(awsCfg.Config))
+	}
+	if awsCreds != nil {
+		env = append(env, "AWS_ACCESS_KEY_ID="+awsCreds.AccessKeyID)
+		env = append(env, "AWS_SECRET_ACCESS_KEY="+awsCreds.SecretAccessKey)
+		if awsCreds.SessionToken != "" {
+			env = append(env, "AWS_SESSION_TOKEN="+awsCreds.SessionToken)
+		}
+	} else if awsCfg.Profile != "" {
+		env = append(env, "AWS_PROFILE="+awsCfg.Profile)
+	}
+	if awsCfg.Region != "" {
+		env = append(env, "AWS_REGION="+awsCfg.Region, "AWS_DEFAULT_REGION="+awsCfg.Region)
+	}
+	return env
+}
+
+// buildSSMArgs builds the aws ssm start-session arguments for port forwarding to a remote host.
+func buildSSMArgs(tunnel config.TunnelConfig) []string {
+	params := fmt.Sprintf(
+		`{"host":["%s"],"portNumber":["%d"],"localPortNumber":["%d"]}`,
+		tunnel.RemoteHost, tunnel.RemotePort, tunnel.LocalPort,
+	)
+	return []string{
+		"ssm", "start-session",
+		"--target", tunnel.Target,
+		"--document-name", "AWS-StartPortForwardingSessionToRemoteHost",
+		"--parameters", params,
+	}
+}
+
+// validateSSMTarget checks that the given EC2 instance ID is registered in SSM.
+func validateSSMTarget(instanceID string, awsEnv []string) error {
+	cmd := exec.Command("aws", "ssm", "describe-instance-information",
+		"--filters", fmt.Sprintf("Key=InstanceIds,Values=%s", instanceID),
+		"--output", "json",
+	)
+	cmd.Env = awsEnv
+	out, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to check SSM registration for %s: %w", instanceID, err)
+	}
+	var result struct {
+		InstanceInformationList []struct{} `json:"InstanceInformationList"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		return fmt.Errorf("failed to parse SSM response: %w", err)
+	}
+	if len(result.InstanceInformationList) == 0 {
+		return fmt.Errorf("instance %q is not registered in SSM — verify the SSM Agent is running and the instance profile has AmazonSSMManagedInstanceCore", instanceID)
+	}
+	return nil
+}
+
 // tunnelState represents the persisted state of running tunnels.
-// Now stores one PID per tunnel for independent management.
+// One entry per tunnel regardless of transport type (ssh or aws).
 type tunnelState struct {
 	StartedAt   time.Time              `json:"started_at"`            // Deprecated
-	TunnelPIDs  map[string]tunnelEntry `json:"tunnel_pids,omitempty"` // New: per-tunnel PIDs
+	TunnelPIDs  map[string]tunnelEntry `json:"tunnel_pids,omitempty"` // All tunnels (ssh and aws)
 	ContextName string                 `json:"context_name"`
 	Tunnels     []config.TunnelConfig  `json:"tunnels,omitempty"` // Deprecated
 	PID         int                    `json:"pid,omitempty"`     // Deprecated: for backwards compat
 }
 
-// tunnelEntry represents a single running tunnel.
+// tunnelEntry represents a single running tunnel (ssh or aws).
 type tunnelEntry struct {
 	StartedAt time.Time           `json:"started_at"`
 	Config    config.TunnelConfig `json:"config"`
@@ -407,6 +574,14 @@ func isProcessRunning(pid int) bool {
 	}
 	err = process.Signal(syscall.Signal(0))
 	return err == nil
+}
+
+// killSSMProcessGroup sends SIGTERM to the entire process group of an SSM tunnel.
+// aws ssm start-session spawns session-manager-plugin as a child — killing only
+// the aws PID leaves the plugin alive. Since we start with Setsid=true the
+// process group ID equals the aws PID, so Kill(-pid) reaches both.
+func killSSMProcessGroup(pid int) {
+	_ = syscall.Kill(-pid, syscall.SIGTERM)
 }
 
 // isPortAvailable checks if a local port is available for binding.
@@ -484,32 +659,38 @@ func runTunnelDown(cmd *cobra.Command, args []string) error {
 	}
 
 	// Determine which tunnels to stop
-	var tunnelsToStop []string
+	var toStop []string
+
 	if len(args) > 0 {
-		// Stop specific tunnel
 		tunnelName := args[0]
 		if _, exists := state.TunnelPIDs[tunnelName]; exists {
-			tunnelsToStop = append(tunnelsToStop, tunnelName)
+			toStop = append(toStop, tunnelName)
 		} else {
 			return fmt.Errorf("tunnel '%s' is not running", tunnelName)
 		}
 	} else {
-		// Stop all tunnels
 		for name := range state.TunnelPIDs {
-			tunnelsToStop = append(tunnelsToStop, name)
+			toStop = append(toStop, name)
 		}
 	}
 
 	stoppedCount := 0
-	for _, name := range tunnelsToStop {
+	var stoppedNames []string
+
+	for _, name := range toStop {
 		entry := state.TunnelPIDs[name]
 		if isProcessRunning(entry.PID) {
-			process, _ := os.FindProcess(entry.PID)
-			process.Signal(syscall.SIGTERM)
+			if entry.Config.Type == "aws" {
+				killSSMProcessGroup(entry.PID)
+			} else {
+				process, _ := os.FindProcess(entry.PID)
+				process.Signal(syscall.SIGTERM)
+			}
 			stoppedCount++
 			green.Printf("✓ Stopped %s (PID: %d)\n", name, entry.PID)
 		}
 		delete(state.TunnelPIDs, name)
+		stoppedNames = append(stoppedNames, name)
 	}
 
 	// Save or remove state file
@@ -523,14 +704,13 @@ func runTunnelDown(cmd *cobra.Command, args []string) error {
 		fmt.Println("No active tunnels to stop.")
 	} else {
 		fmt.Printf("\n%d tunnel(s) stopped.\n", stoppedCount)
-		// Send tunnel.down audit event
-		sendTunnelEvent(mgr, ctx.Name, string(ctx.Environment), "tunnel.down", tunnelsToStop, true)
+		sendTunnelEvent(mgr, ctx.Name, string(ctx.Environment), "tunnel.down", stoppedNames, true)
 	}
 
 	return nil
 }
 
-// pendingTunnel holds information about a tunnel being started.
+// pendingTunnel holds information about a tunnel being started (ssh or aws).
 type pendingTunnel struct {
 	config      config.TunnelConfig
 	actualPort  int
@@ -544,15 +724,13 @@ type pendingTunnel struct {
 // startAutoConnectTunnels starts tunnels that have auto_connect enabled.
 // Called during context switch. Returns (successfulTunnels, failedTunnels, error).
 func startAutoConnectTunnels(mgr *config.Manager, ctx *config.ContextConfig) ([]string, []string, error) {
-	// Filter tunnels with auto_connect
-	var autoConnectTunnels []config.TunnelConfig
+	var autoConnect []config.TunnelConfig
 	for _, t := range ctx.Tunnels {
 		if t.AutoConnect {
-			autoConnectTunnels = append(autoConnectTunnels, t)
+			autoConnect = append(autoConnect, t)
 		}
 	}
-
-	if len(autoConnectTunnels) == 0 {
+	if len(autoConnect) == 0 {
 		return nil, nil, nil
 	}
 
@@ -578,109 +756,187 @@ func startAutoConnectTunnels(mgr *config.Manager, ctx *config.ContextConfig) ([]
 	yellow := color.New(color.FgYellow)
 	green := color.New(color.FgGreen)
 
-	// Phase 1: Start all tunnels in parallel
-	var pending []pendingTunnel
-	for _, t := range autoConnectTunnels {
-		// Check if this tunnel is already running
-		if entry, exists := state.TunnelPIDs[t.Name]; exists {
-			if isProcessRunning(entry.PID) {
-				green.Fprintf(os.Stderr, "✓ Tunnel %s already running (PID: %d)\n", t.Name, entry.PID)
-				continue
-			}
-			delete(state.TunnelPIDs, t.Name)
-		}
-
-		// Find available port (in case configured port is in use)
-		actualPort, portChanged := findAvailablePort(t.LocalPort)
-		tunnelConfig := t
-		tunnelConfig.LocalPort = actualPort
-
-		// Build SSH args for this single tunnel
-		sshArgs := buildSSHArgs(ctx.SSH, []config.TunnelConfig{tunnelConfig})
-
-		// Start SSH process in background
-		sshCmd := exec.Command("ssh", sshArgs...)
-		sshCmd.SysProcAttr = &syscall.SysProcAttr{
-			Setsid: true,
-		}
-
-		// Redirect output to log file
-		logFile := filepath.Join(stateDir, fmt.Sprintf("%s-%s.log", ctx.Name, t.Name))
-		logFd, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
-		if err != nil {
-			yellow.Fprintf(os.Stderr, "⚠ Tunnel %s: failed to create log file: %v\n", t.Name, err)
-			continue
-		}
-		sshCmd.Stdout = logFd
-		sshCmd.Stderr = logFd
-
-		if err := sshCmd.Start(); err != nil {
-			logFd.Close()
-			yellow.Fprintf(os.Stderr, "⚠ Tunnel %s: failed to start: %v\n", t.Name, err)
-			continue
-		}
-
-		// Start goroutine to wait for process exit
-		exitCh := make(chan error, 1)
-		go func(cmd *exec.Cmd) {
-			exitCh <- cmd.Wait()
-		}(sshCmd)
-
-		pending = append(pending, pendingTunnel{
-			config:      tunnelConfig,
-			actualPort:  actualPort,
-			portChanged: portChanged,
-			cmd:         sshCmd,
-			logFile:     logFile,
-			logFd:       logFd,
-			exitCh:      exitCh,
-		})
-	}
-
-	if len(pending) == 0 {
-		return nil, nil, nil
-	}
-
-	// Phase 2: Wait for tunnels to either connect or fail
-	// SSH auth failures typically complete within 2-3 seconds
-	timeout := 5 // default 5 seconds
+	timeout := 5
 	if ctx.SSH != nil && ctx.SSH.TunnelTimeout > 0 {
 		timeout = ctx.SSH.TunnelTimeout
 	}
-	time.Sleep(time.Duration(timeout) * time.Second)
 
-	// Phase 3: Check results and report
+	// Pre-flight checks — run once before starting any tunnel
+	sshOK := ctx.SSH != nil && ctx.SSH.Bastion.Host != ""
+	ssmOK := false
+	var awsEnv []string
+
+	hasSSH, hasAWS := false, false
+	for _, t := range autoConnect {
+		if t.Type == "aws" {
+			hasAWS = true
+		} else {
+			hasSSH = true
+		}
+	}
+	if hasSSH && !sshOK {
+		yellow.Fprintf(os.Stderr, "⚠ SSH auto-connect skipped: no SSH bastion configured\n")
+	}
+	if hasAWS {
+		if ctx.AWS == nil {
+			yellow.Fprintf(os.Stderr, "⚠ AWS auto-connect skipped: no aws config found\n")
+		} else if err := checkSSMDependencies(); err != nil {
+			yellow.Fprintf(os.Stderr, "⚠ AWS auto-connect skipped: %v\n", err)
+		} else {
+			var awsCreds *config.AWSCredentials
+			if ctx.AWS.UseVault {
+				awsCreds = mgr.LoadAWSCredentials(ctx.Name)
+			}
+			awsEnv = buildAWSEnv(ctx.AWS, awsCreds)
+			ssmOK = true
+		}
+	}
+
 	var startedTunnels []string
 	var failedTunnels []string
-	for _, p := range pending {
-		t := p.config
 
-		// Check if process exited (failed) or still running (connected)
-		select {
-		case <-p.exitCh:
-			// Process exited - connection failed
-			p.logFd.Close()
-			logContent, _ := os.ReadFile(p.logFile)
-			errMsg := strings.TrimSpace(string(logContent))
-			if idx := strings.Index(errMsg, "\n"); idx > 0 {
-				errMsg = errMsg[:idx]
+	// Phase 1: Start all tunnels in parallel
+	var pending []pendingTunnel
+	for _, t := range autoConnect {
+		if t.Type == "aws" {
+			if !ssmOK {
+				continue
 			}
-			yellow.Fprintf(os.Stderr, "⚠ Tunnel %s: %s\n", t.Name, errMsg)
-			failedTunnels = append(failedTunnels, t.Name)
-		default:
-			// Process still running - connected successfully
-			state.TunnelPIDs[t.Name] = tunnelEntry{
-				PID:       p.cmd.Process.Pid,
-				StartedAt: time.Now(),
-				Config:    t,
-			}
-			startedTunnels = append(startedTunnels, t.Name)
 
-			if p.portChanged {
-				green.Fprintf(os.Stderr, "✓ Tunnel %s: localhost:%d → %s:%d ", t.Name, p.actualPort, t.RemoteHost, t.RemotePort)
-				yellow.Fprintf(os.Stderr, "(port %d in use)\n", t.LocalPort)
-			} else {
-				green.Fprintf(os.Stderr, "✓ Tunnel %s: localhost:%d → %s:%d\n", t.Name, t.LocalPort, t.RemoteHost, t.RemotePort)
+			if entry, exists := state.TunnelPIDs[t.Name]; exists {
+				if isProcessRunning(entry.PID) {
+					configChanged := entry.Config.Target != t.Target ||
+						entry.Config.RemoteHost != t.RemoteHost ||
+						entry.Config.RemotePort != t.RemotePort ||
+						entry.Config.LocalPort != t.LocalPort
+					if !configChanged {
+						green.Fprintf(os.Stderr, "✓ Tunnel %s already running (PID: %d)\n", t.Name, entry.PID)
+						continue
+					}
+					killSSMProcessGroup(entry.PID)
+				}
+				delete(state.TunnelPIDs, t.Name)
+			}
+
+			actualPort, portChanged := findAvailablePort(t.LocalPort)
+			tunnelConfig := t
+			tunnelConfig.LocalPort = actualPort
+
+			ssmArgs := buildSSMArgs(tunnelConfig)
+			cmd := exec.Command("aws", ssmArgs...)
+			cmd.Env = awsEnv
+			cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+
+			logFile := filepath.Join(stateDir, fmt.Sprintf("%s-%s.log", ctx.Name, t.Name))
+			logFd, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+			if err != nil {
+				yellow.Fprintf(os.Stderr, "⚠ Tunnel %s: failed to create log file: %v\n", t.Name, err)
+				continue
+			}
+			cmd.Stdout = logFd
+			cmd.Stderr = logFd
+
+			if err := cmd.Start(); err != nil {
+				logFd.Close()
+				yellow.Fprintf(os.Stderr, "⚠ Tunnel %s: failed to start: %v\n", t.Name, err)
+				failedTunnels = append(failedTunnels, t.Name)
+				continue
+			}
+
+			exitCh := make(chan error, 1)
+			go func(c *exec.Cmd) { exitCh <- c.Wait() }(cmd)
+
+			pending = append(pending, pendingTunnel{
+				config:      tunnelConfig,
+				actualPort:  actualPort,
+				portChanged: portChanged,
+				cmd:         cmd,
+				logFile:     logFile,
+				logFd:       logFd,
+				exitCh:      exitCh,
+			})
+		} else {
+			if !sshOK {
+				continue
+			}
+
+			if entry, exists := state.TunnelPIDs[t.Name]; exists {
+				if isProcessRunning(entry.PID) {
+					green.Fprintf(os.Stderr, "✓ Tunnel %s already running (PID: %d)\n", t.Name, entry.PID)
+					continue
+				}
+				delete(state.TunnelPIDs, t.Name)
+			}
+
+			actualPort, portChanged := findAvailablePort(t.LocalPort)
+			tunnelConfig := t
+			tunnelConfig.LocalPort = actualPort
+
+			sshArgs := buildSSHArgs(ctx.SSH, []config.TunnelConfig{tunnelConfig})
+			cmd := exec.Command("ssh", sshArgs...)
+			cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+
+			logFile := filepath.Join(stateDir, fmt.Sprintf("%s-%s.log", ctx.Name, t.Name))
+			logFd, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+			if err != nil {
+				yellow.Fprintf(os.Stderr, "⚠ Tunnel %s: failed to create log file: %v\n", t.Name, err)
+				continue
+			}
+			cmd.Stdout = logFd
+			cmd.Stderr = logFd
+
+			if err := cmd.Start(); err != nil {
+				logFd.Close()
+				yellow.Fprintf(os.Stderr, "⚠ Tunnel %s: failed to start: %v\n", t.Name, err)
+				continue
+			}
+
+			exitCh := make(chan error, 1)
+			go func(c *exec.Cmd) { exitCh <- c.Wait() }(cmd)
+
+			pending = append(pending, pendingTunnel{
+				config:      tunnelConfig,
+				actualPort:  actualPort,
+				portChanged: portChanged,
+				cmd:         cmd,
+				logFile:     logFile,
+				logFd:       logFd,
+				exitCh:      exitCh,
+			})
+		}
+	}
+
+	if len(pending) > 0 {
+		// Phase 2: Wait once for all tunnels (ssh and aws together)
+		time.Sleep(time.Duration(timeout) * time.Second)
+
+		// Phase 3: Check results
+		for _, p := range pending {
+			t := p.config
+			select {
+			case <-p.exitCh:
+				p.logFd.Close()
+				logContent, _ := os.ReadFile(p.logFile)
+				errMsg := strings.TrimSpace(string(logContent))
+				if idx := strings.Index(errMsg, "\n"); idx > 0 {
+					errMsg = errMsg[:idx]
+				}
+				yellow.Fprintf(os.Stderr, "⚠ Tunnel %s: %s\n", t.Name, errMsg)
+				failedTunnels = append(failedTunnels, t.Name)
+			default:
+				state.TunnelPIDs[t.Name] = tunnelEntry{
+					PID:       p.cmd.Process.Pid,
+					StartedAt: time.Now(),
+					Config:    t,
+				}
+				startedTunnels = append(startedTunnels, t.Name)
+
+				if p.portChanged {
+					green.Fprintf(os.Stderr, "✓ Tunnel %s: localhost:%d → %s:%d ", t.Name, p.actualPort, t.RemoteHost, t.RemotePort)
+					yellow.Fprintf(os.Stderr, "(port %d in use)\n", t.LocalPort)
+				} else {
+					green.Fprintf(os.Stderr, "✓ Tunnel %s: localhost:%d → %s:%d\n", t.Name, t.LocalPort, t.RemoteHost, t.RemotePort)
+				}
 			}
 		}
 	}
@@ -758,7 +1014,7 @@ func runTunnelStatus(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Tunnels for context '%s'\n\n", ctx.Name)
 
 	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"TUNNEL", "LOCAL", "REMOTE", "PID", "STATUS"})
+	table.SetHeader([]string{"TUNNEL", "TYPE", "LOCAL", "REMOTE", "PID", "STATUS"})
 	table.SetBorder(false)
 	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
@@ -769,29 +1025,31 @@ func runTunnelStatus(cmd *cobra.Command, args []string) error {
 	table.SetTablePadding("  ")
 	table.SetNoWhiteSpace(true)
 
-	activeCount := 0
-	staleNames := []string{}
+	var stale []string
+
 	for name, entry := range state.TunnelPIDs {
 		t := entry.Config
+		tunnelType := t.Type
+		if tunnelType == "" {
+			tunnelType = "ssh"
+		}
 		localAddr := fmt.Sprintf("localhost:%d", t.LocalPort)
 		remoteAddr := fmt.Sprintf("%s:%d", t.RemoteHost, t.RemotePort)
 		pidStr := fmt.Sprintf("%d", entry.PID)
 		var statusStr string
 		if isProcessRunning(entry.PID) {
 			statusStr = "● connected"
-			activeCount++
 		} else {
 			statusStr = "○ stopped"
-			staleNames = append(staleNames, name)
+			stale = append(stale, name)
 		}
-		table.Append([]string{name, localAddr, remoteAddr, pidStr, statusStr})
+		table.Append([]string{name, tunnelType, localAddr, remoteAddr, pidStr, statusStr})
 	}
 
-	// Clean up stale entries
-	for _, name := range staleNames {
+	for _, name := range stale {
 		delete(state.TunnelPIDs, name)
 	}
-	if len(staleNames) > 0 {
+	if len(stale) > 0 {
 		if len(state.TunnelPIDs) == 0 {
 			os.Remove(stateFile)
 		} else {
@@ -801,7 +1059,6 @@ func runTunnelStatus(cmd *cobra.Command, args []string) error {
 
 	table.Render()
 
-	// Show log file location
 	logFile := filepath.Join(stateDir, ctx.Name+".log")
 	fmt.Printf("\nLog file: %s\n", logFile)
 

--- a/internal/cli/tunnel.go
+++ b/internal/cli/tunnel.go
@@ -471,7 +471,13 @@ func checkSSMDependencies() error {
 // buildAWSEnv builds a cmd.Env slice with AWS credentials injected explicitly.
 // This is required for auto_connect tunnels started before the shell hook sources the env file.
 func buildAWSEnv(awsCfg *config.AWSConfig, awsCreds *config.AWSCredentials) []string {
-	env := os.Environ()
+	hostEnv := os.Environ()
+	env := make([]string, 0, len(hostEnv))
+	for _, e := range hostEnv {
+		if !strings.HasPrefix(e, "AWS_") {
+			env = append(env, e)
+		}
+	}
 	if awsCfg.Config != "" {
 		env = append(env, "AWS_CONFIG_FILE="+expandPath(awsCfg.Config))
 	}

--- a/internal/cli/tunnel_ssm_test.go
+++ b/internal/cli/tunnel_ssm_test.go
@@ -1,0 +1,361 @@
+// SPDX-FileCopyrightText: 2026 Enrique Alonso <enrialonso@gmail.com>
+// SPDX-License-Identifier: MIT
+
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/vlebo/ctx/internal/config"
+)
+
+func TestCheckSSMDependencies_MissingAWS(t *testing.T) {
+	// Put an empty PATH so neither aws nor session-manager-plugin is found
+	tmpDir := t.TempDir()
+	t.Setenv("PATH", tmpDir)
+
+	err := checkSSMDependencies()
+	if err == nil {
+		t.Fatal("expected error when aws CLI is missing, got nil")
+	}
+}
+
+func TestCheckSSMDependencies_MissingPlugin(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a fake aws binary
+	awsBin := filepath.Join(tmpDir, "aws")
+	if err := os.WriteFile(awsBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PATH", tmpDir)
+
+	err := checkSSMDependencies()
+	if err == nil {
+		t.Fatal("expected error when session-manager-plugin is missing, got nil")
+	}
+}
+
+func TestCheckSSMDependencies_BothPresent(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	for _, bin := range []string{"aws", "session-manager-plugin"} {
+		p := filepath.Join(tmpDir, bin)
+		if err := os.WriteFile(p, []byte("#!/bin/sh\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Setenv("PATH", tmpDir)
+
+	if err := checkSSMDependencies(); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestBuildSSMArgs(t *testing.T) {
+	tunnel := config.SSMTunnelConfig{
+		Name:       "postgres",
+		SSMTarget:  "i-0abc123def456789a",
+		RemoteHost: "db.internal.vpc",
+		RemotePort: 5432,
+		LocalPort:  5432,
+	}
+
+	args := buildSSMArgs(tunnel)
+
+	expected := []string{
+		"ssm", "start-session",
+		"--target", "i-0abc123def456789a",
+		"--document-name", "AWS-StartPortForwardingSessionToRemoteHost",
+		"--parameters", `{"host":["db.internal.vpc"],"portNumber":["5432"],"localPortNumber":["5432"]}`,
+	}
+
+	if len(args) != len(expected) {
+		t.Fatalf("got %d args, want %d: %v", len(args), len(expected), args)
+	}
+	for i, a := range args {
+		if a != expected[i] {
+			t.Errorf("arg[%d]: got %q, want %q", i, a, expected[i])
+		}
+	}
+}
+
+func TestBuildSSMArgs_PortSubstitution(t *testing.T) {
+	tunnel := config.SSMTunnelConfig{
+		SSMTarget:  "i-0abc123def456789a",
+		RemoteHost: "cache.internal",
+		RemotePort: 6379,
+		LocalPort:  16379, // remapped port
+	}
+
+	args := buildSSMArgs(tunnel)
+
+	// Find --parameters arg
+	var params string
+	for i, a := range args {
+		if a == "--parameters" && i+1 < len(args) {
+			params = args[i+1]
+			break
+		}
+	}
+
+	want := `{"host":["cache.internal"],"portNumber":["6379"],"localPortNumber":["16379"]}`
+	if params != want {
+		t.Errorf("params: got %q, want %q", params, want)
+	}
+}
+
+func TestValidateSSMTarget_Found(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Fake aws binary that returns a non-empty InstanceInformationList
+	response := map[string]any{
+		"InstanceInformationList": []map[string]string{
+			{"InstanceId": "i-0abc123def456789a"},
+		},
+	}
+	out, _ := json.Marshal(response)
+	script := fmt.Sprintf("#!/bin/sh\necho '%s'\n", string(out))
+	if err := os.WriteFile(filepath.Join(tmpDir, "aws"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PATH", tmpDir)
+	awsEnv := append(os.Environ(), "PATH="+tmpDir)
+
+	if err := validateSSMTarget("i-0abc123def456789a", awsEnv); err != nil {
+		t.Fatalf("expected no error for registered instance, got: %v", err)
+	}
+}
+
+func TestValidateSSMTarget_NotRegistered(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Fake aws binary that returns an empty list
+	response := map[string]any{
+		"InstanceInformationList": []any{},
+	}
+	out, _ := json.Marshal(response)
+	script := fmt.Sprintf("#!/bin/sh\necho '%s'\n", string(out))
+	if err := os.WriteFile(filepath.Join(tmpDir, "aws"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PATH", tmpDir)
+	awsEnv := append(os.Environ(), "PATH="+tmpDir)
+
+	err := validateSSMTarget("i-0deadbeef00000000", awsEnv)
+	if err == nil {
+		t.Fatal("expected error for unregistered instance, got nil")
+	}
+}
+
+func TestBuildAWSEnv_WithVaultCreds(t *testing.T) {
+	awsCfg := &config.AWSConfig{
+		Region:  "eu-west-1",
+		Profile: "my-profile",
+	}
+	creds := &config.AWSCredentials{
+		AccessKeyID:     "AKIAIOSFODNN7EXAMPLE",
+		SecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+		SessionToken:    "token123",
+	}
+
+	env := buildAWSEnv(awsCfg, creds)
+
+	check := func(key, want string) {
+		t.Helper()
+		for _, e := range env {
+			if len(e) > len(key)+1 && e[:len(key)+1] == key+"=" {
+				got := e[len(key)+1:]
+				if got != want {
+					t.Errorf("%s: got %q, want %q", key, got, want)
+				}
+				return
+			}
+		}
+		t.Errorf("missing env var %s", key)
+	}
+
+	check("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
+	check("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+	check("AWS_SESSION_TOKEN", "token123")
+	check("AWS_REGION", "eu-west-1")
+	check("AWS_DEFAULT_REGION", "eu-west-1")
+}
+
+func TestBuildAWSEnv_WithProfile(t *testing.T) {
+	awsCfg := &config.AWSConfig{
+		Region:  "us-east-1",
+		Profile: "sso-prod",
+	}
+
+	env := buildAWSEnv(awsCfg, nil)
+
+	hasProfile := false
+	hasNoKey := true
+	for _, e := range env {
+		if e == "AWS_PROFILE=sso-prod" {
+			hasProfile = true
+		}
+		if len(e) > 17 && e[:17] == "AWS_ACCESS_KEY_ID" {
+			hasNoKey = false
+		}
+	}
+	if !hasProfile {
+		t.Error("AWS_PROFILE not set when no vault creds")
+	}
+	if !hasNoKey {
+		t.Error("AWS_ACCESS_KEY_ID should not be set when using profile")
+	}
+}
+
+func TestBuildAWSEnv_CustomConfigFile(t *testing.T) {
+	awsCfg := &config.AWSConfig{
+		Profile: "myproject",
+		Region:  "eu-west-1",
+		Config:  "/home/user/.aws/config_myproject",
+	}
+
+	env := buildAWSEnv(awsCfg, nil)
+
+	hasConfigFile := false
+	for _, e := range env {
+		if e == "AWS_CONFIG_FILE=/home/user/.aws/config_myproject" {
+			hasConfigFile = true
+		}
+	}
+	if !hasConfigFile {
+		t.Error("AWS_CONFIG_FILE not set when aws.config is configured")
+	}
+}
+
+// writeTunnelStateFile writes a tunnelState JSON file under stateDir/tunnels/<context>.json.
+func writeTunnelStateFile(t *testing.T, stateDir, contextName string, state *tunnelState) string {
+	t.Helper()
+	tunnelDir := filepath.Join(stateDir, "tunnels")
+	if err := os.MkdirAll(tunnelDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stateFile := filepath.Join(tunnelDir, contextName+".json")
+	if err := saveTunnelState(stateFile, state); err != nil {
+		t.Fatal(err)
+	}
+	return stateFile
+}
+
+// startSleepProcess starts a long-running sleep subprocess in its own process group
+// (Setsid: true), mirroring how SSM tunnels are launched. This is required so that
+// killSSMProcessGroup (which uses Kill(-pid, SIGTERM)) actually reaches the process.
+// Returns the PID and a reap function to call after killing to avoid zombies.
+func startSleepProcess(t *testing.T) (pid int, reap func()) {
+	t.Helper()
+	cmd := exec.Command("sleep", "30")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = cmd.Process.Kill(); _ = cmd.Wait() })
+	return cmd.Process.Pid, func() { _ = cmd.Wait() }
+}
+
+func TestStopContextTunnels_StopsSSMTunnels(t *testing.T) {
+	stateDir := t.TempDir()
+	pid, reap := startSleepProcess(t)
+
+	state := &tunnelState{
+		TunnelPIDs: make(map[string]tunnelEntry),
+		SSMTunnelPIDs: map[string]ssmTunnelEntry{
+			"postgres": {
+				PID:       pid,
+				StartedAt: time.Now(),
+				Config: config.SSMTunnelConfig{
+					Name:       "postgres",
+					SSMTarget:  "i-0abc123def456789a",
+					RemoteHost: "db.internal.vpc",
+					RemotePort: 5432,
+					LocalPort:  5432,
+				},
+			},
+		},
+	}
+	stateFile := writeTunnelStateFile(t, stateDir, "test-ctx", state)
+
+	stopped, err := stopContextTunnels(stateDir, "test-ctx")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stopped != 1 {
+		t.Errorf("expected 1 tunnel stopped, got %d", stopped)
+	}
+
+	// Reap the zombie so kill -0 no longer sees it
+	reap()
+	if isProcessRunning(pid) {
+		t.Error("SSM tunnel process should have been stopped")
+	}
+	if _, err := os.Stat(stateFile); !os.IsNotExist(err) {
+		t.Error("state file should have been removed")
+	}
+}
+
+func TestStopContextTunnels_StopsBothSSHAndSSM(t *testing.T) {
+	stateDir := t.TempDir()
+	sshPID, reapSSH := startSleepProcess(t)
+	ssmPID, reapSSM := startSleepProcess(t)
+
+	state := &tunnelState{
+		TunnelPIDs: map[string]tunnelEntry{
+			"legacy": {PID: sshPID, StartedAt: time.Now()},
+		},
+		SSMTunnelPIDs: map[string]ssmTunnelEntry{
+			"postgres": {
+				PID:       ssmPID,
+				StartedAt: time.Now(),
+				Config:    config.SSMTunnelConfig{Name: "postgres"},
+			},
+		},
+	}
+	stateFile := writeTunnelStateFile(t, stateDir, "test-ctx", state)
+
+	stopped, err := stopContextTunnels(stateDir, "test-ctx")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stopped != 2 {
+		t.Errorf("expected 2 tunnels stopped, got %d", stopped)
+	}
+
+	reapSSH()
+	reapSSM()
+	if isProcessRunning(sshPID) {
+		t.Error("SSH tunnel process should have been stopped")
+	}
+	if isProcessRunning(ssmPID) {
+		t.Error("SSM tunnel process should have been stopped")
+	}
+	if _, err := os.Stat(stateFile); !os.IsNotExist(err) {
+		t.Error("state file should have been removed")
+	}
+}
+
+func TestStopContextTunnels_NoStateFile(t *testing.T) {
+	stateDir := t.TempDir()
+
+	stopped, err := stopContextTunnels(stateDir, "nonexistent-ctx")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stopped != 0 {
+		t.Errorf("expected 0 tunnels stopped, got %d", stopped)
+	}
+}

--- a/internal/cli/tunnel_ssm_test.go
+++ b/internal/cli/tunnel_ssm_test.go
@@ -1,0 +1,365 @@
+// SPDX-FileCopyrightText: 2026 Enrique Alonso <enrialonso@gmail.com>
+// SPDX-License-Identifier: MIT
+
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/vlebo/ctx/internal/config"
+)
+
+func TestCheckSSMDependencies_MissingAWS(t *testing.T) {
+	// Put an empty PATH so neither aws nor session-manager-plugin is found
+	tmpDir := t.TempDir()
+	t.Setenv("PATH", tmpDir)
+
+	err := checkSSMDependencies()
+	if err == nil {
+		t.Fatal("expected error when aws CLI is missing, got nil")
+	}
+}
+
+func TestCheckSSMDependencies_MissingPlugin(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a fake aws binary
+	awsBin := filepath.Join(tmpDir, "aws")
+	if err := os.WriteFile(awsBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PATH", tmpDir)
+
+	err := checkSSMDependencies()
+	if err == nil {
+		t.Fatal("expected error when session-manager-plugin is missing, got nil")
+	}
+}
+
+func TestCheckSSMDependencies_BothPresent(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	for _, bin := range []string{"aws", "session-manager-plugin"} {
+		p := filepath.Join(tmpDir, bin)
+		if err := os.WriteFile(p, []byte("#!/bin/sh\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Setenv("PATH", tmpDir)
+
+	if err := checkSSMDependencies(); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestBuildSSMArgs(t *testing.T) {
+	tunnel := config.TunnelConfig{
+		Name:       "postgres",
+		Type:       "aws",
+		Target:     "i-0abc123def456789a",
+		RemoteHost: "db.internal.vpc",
+		RemotePort: 5432,
+		LocalPort:  5432,
+	}
+
+	args := buildSSMArgs(tunnel)
+
+	expected := []string{
+		"ssm", "start-session",
+		"--target", "i-0abc123def456789a",
+		"--document-name", "AWS-StartPortForwardingSessionToRemoteHost",
+		"--parameters", `{"host":["db.internal.vpc"],"portNumber":["5432"],"localPortNumber":["5432"]}`,
+	}
+
+	if len(args) != len(expected) {
+		t.Fatalf("got %d args, want %d: %v", len(args), len(expected), args)
+	}
+	for i, a := range args {
+		if a != expected[i] {
+			t.Errorf("arg[%d]: got %q, want %q", i, a, expected[i])
+		}
+	}
+}
+
+func TestBuildSSMArgs_PortSubstitution(t *testing.T) {
+	tunnel := config.TunnelConfig{
+		Type:       "aws",
+		Target:     "i-0abc123def456789a",
+		RemoteHost: "cache.internal",
+		RemotePort: 6379,
+		LocalPort:  16379, // remapped port
+	}
+
+	args := buildSSMArgs(tunnel)
+
+	// Find --parameters arg
+	var params string
+	for i, a := range args {
+		if a == "--parameters" && i+1 < len(args) {
+			params = args[i+1]
+			break
+		}
+	}
+
+	want := `{"host":["cache.internal"],"portNumber":["6379"],"localPortNumber":["16379"]}`
+	if params != want {
+		t.Errorf("params: got %q, want %q", params, want)
+	}
+}
+
+func TestValidateSSMTarget_Found(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Fake aws binary that returns a non-empty InstanceInformationList
+	response := map[string]any{
+		"InstanceInformationList": []map[string]string{
+			{"InstanceId": "i-0abc123def456789a"},
+		},
+	}
+	out, _ := json.Marshal(response)
+	script := fmt.Sprintf("#!/bin/sh\necho '%s'\n", string(out))
+	if err := os.WriteFile(filepath.Join(tmpDir, "aws"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PATH", tmpDir)
+	awsEnv := append(os.Environ(), "PATH="+tmpDir)
+
+	if err := validateSSMTarget("i-0abc123def456789a", awsEnv); err != nil {
+		t.Fatalf("expected no error for registered instance, got: %v", err)
+	}
+}
+
+func TestValidateSSMTarget_NotRegistered(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Fake aws binary that returns an empty list
+	response := map[string]any{
+		"InstanceInformationList": []any{},
+	}
+	out, _ := json.Marshal(response)
+	script := fmt.Sprintf("#!/bin/sh\necho '%s'\n", string(out))
+	if err := os.WriteFile(filepath.Join(tmpDir, "aws"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PATH", tmpDir)
+	awsEnv := append(os.Environ(), "PATH="+tmpDir)
+
+	err := validateSSMTarget("i-0deadbeef00000000", awsEnv)
+	if err == nil {
+		t.Fatal("expected error for unregistered instance, got nil")
+	}
+}
+
+func TestBuildAWSEnv_WithVaultCreds(t *testing.T) {
+	awsCfg := &config.AWSConfig{
+		Region:  "eu-west-1",
+		Profile: "my-profile",
+	}
+	creds := &config.AWSCredentials{
+		AccessKeyID:     "AKIAIOSFODNN7EXAMPLE",
+		SecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+		SessionToken:    "token123",
+	}
+
+	env := buildAWSEnv(awsCfg, creds)
+
+	check := func(key, want string) {
+		t.Helper()
+		for _, e := range env {
+			if len(e) > len(key)+1 && e[:len(key)+1] == key+"=" {
+				got := e[len(key)+1:]
+				if got != want {
+					t.Errorf("%s: got %q, want %q", key, got, want)
+				}
+				return
+			}
+		}
+		t.Errorf("missing env var %s", key)
+	}
+
+	check("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
+	check("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+	check("AWS_SESSION_TOKEN", "token123")
+	check("AWS_REGION", "eu-west-1")
+	check("AWS_DEFAULT_REGION", "eu-west-1")
+}
+
+func TestBuildAWSEnv_WithProfile(t *testing.T) {
+	awsCfg := &config.AWSConfig{
+		Region:  "us-east-1",
+		Profile: "sso-prod",
+	}
+
+	env := buildAWSEnv(awsCfg, nil)
+
+	hasProfile := false
+	hasNoKey := true
+	for _, e := range env {
+		if e == "AWS_PROFILE=sso-prod" {
+			hasProfile = true
+		}
+		if len(e) > 17 && e[:17] == "AWS_ACCESS_KEY_ID" {
+			hasNoKey = false
+		}
+	}
+	if !hasProfile {
+		t.Error("AWS_PROFILE not set when no vault creds")
+	}
+	if !hasNoKey {
+		t.Error("AWS_ACCESS_KEY_ID should not be set when using profile")
+	}
+}
+
+func TestBuildAWSEnv_CustomConfigFile(t *testing.T) {
+	awsCfg := &config.AWSConfig{
+		Profile: "myproject",
+		Region:  "eu-west-1",
+		Config:  "/home/user/.aws/config_myproject",
+	}
+
+	env := buildAWSEnv(awsCfg, nil)
+
+	hasConfigFile := false
+	for _, e := range env {
+		if e == "AWS_CONFIG_FILE=/home/user/.aws/config_myproject" {
+			hasConfigFile = true
+		}
+	}
+	if !hasConfigFile {
+		t.Error("AWS_CONFIG_FILE not set when aws.config is configured")
+	}
+}
+
+// writeTunnelStateFile writes a tunnelState JSON file under stateDir/tunnels/<context>.json.
+func writeTunnelStateFile(t *testing.T, stateDir, contextName string, state *tunnelState) string {
+	t.Helper()
+	tunnelDir := filepath.Join(stateDir, "tunnels")
+	if err := os.MkdirAll(tunnelDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stateFile := filepath.Join(tunnelDir, contextName+".json")
+	if err := saveTunnelState(stateFile, state); err != nil {
+		t.Fatal(err)
+	}
+	return stateFile
+}
+
+// startSleepProcess starts a long-running sleep subprocess in its own process group
+// (Setsid: true), mirroring how tunnels are launched. This is required so that
+// killSSMProcessGroup (which uses Kill(-pid, SIGTERM)) actually reaches the process.
+// Returns the PID and a reap function to call after killing to avoid zombies.
+func startSleepProcess(t *testing.T) (pid int, reap func()) {
+	t.Helper()
+	cmd := exec.Command("sleep", "30")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = cmd.Process.Kill(); _ = cmd.Wait() })
+	return cmd.Process.Pid, func() { _ = cmd.Wait() }
+}
+
+func TestStopContextTunnels_StopsAWSTunnels(t *testing.T) {
+	stateDir := t.TempDir()
+	pid, reap := startSleepProcess(t)
+
+	state := &tunnelState{
+		TunnelPIDs: map[string]tunnelEntry{
+			"postgres": {
+				PID:       pid,
+				StartedAt: time.Now(),
+				Config: config.TunnelConfig{
+					Name:       "postgres",
+					Type:       "aws",
+					Target:     "i-0abc123def456789a",
+					RemoteHost: "db.internal.vpc",
+					RemotePort: 5432,
+					LocalPort:  5432,
+				},
+			},
+		},
+	}
+	stateFile := writeTunnelStateFile(t, stateDir, "test-ctx", state)
+
+	stopped, err := stopContextTunnels(stateDir, "test-ctx")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stopped != 1 {
+		t.Errorf("expected 1 tunnel stopped, got %d", stopped)
+	}
+
+	// Reap the zombie so kill -0 no longer sees it
+	reap()
+	if isProcessRunning(pid) {
+		t.Error("AWS tunnel process should have been stopped")
+	}
+	if _, err := os.Stat(stateFile); !os.IsNotExist(err) {
+		t.Error("state file should have been removed")
+	}
+}
+
+func TestStopContextTunnels_StopsBothSSHAndAWS(t *testing.T) {
+	stateDir := t.TempDir()
+	sshPID, reapSSH := startSleepProcess(t)
+	awsPID, reapAWS := startSleepProcess(t)
+
+	state := &tunnelState{
+		TunnelPIDs: map[string]tunnelEntry{
+			"legacy": {
+				PID:       sshPID,
+				StartedAt: time.Now(),
+				Config:    config.TunnelConfig{Name: "legacy"},
+			},
+			"postgres": {
+				PID:       awsPID,
+				StartedAt: time.Now(),
+				Config:    config.TunnelConfig{Name: "postgres", Type: "aws"},
+			},
+		},
+	}
+	stateFile := writeTunnelStateFile(t, stateDir, "test-ctx", state)
+
+	stopped, err := stopContextTunnels(stateDir, "test-ctx")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stopped != 2 {
+		t.Errorf("expected 2 tunnels stopped, got %d", stopped)
+	}
+
+	reapSSH()
+	reapAWS()
+	if isProcessRunning(sshPID) {
+		t.Error("SSH tunnel process should have been stopped")
+	}
+	if isProcessRunning(awsPID) {
+		t.Error("AWS tunnel process should have been stopped")
+	}
+	if _, err := os.Stat(stateFile); !os.IsNotExist(err) {
+		t.Error("state file should have been removed")
+	}
+}
+
+func TestStopContextTunnels_NoStateFile(t *testing.T) {
+	stateDir := t.TempDir()
+
+	stopped, err := stopContextTunnels(stateDir, "nonexistent-ctx")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stopped != 0 {
+		t.Errorf("expected 0 tunnels stopped, got %d", stopped)
+	}
+}

--- a/internal/cli/tunnel_ssm_test.go
+++ b/internal/cli/tunnel_ssm_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -238,6 +239,53 @@ func TestBuildAWSEnv_CustomConfigFile(t *testing.T) {
 	}
 	if !hasConfigFile {
 		t.Error("AWS_CONFIG_FILE not set when aws.config is configured")
+	}
+}
+
+func TestBuildAWSEnv_HostVarsAreFiltered(t *testing.T) {
+	t.Setenv("AWS_REGION", "us-east-1")
+	t.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	t.Setenv("AWS_PROFILE", "host-profile")
+	t.Setenv("AWS_ACCESS_KEY_ID", "HOST_KEY_ID")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "HOST_SECRET")
+
+	awsCfg := &config.AWSConfig{Region: "eu-west-1"}
+	creds := &config.AWSCredentials{
+		AccessKeyID:     "CTX_KEY_ID",
+		SecretAccessKey: "CTX_SECRET",
+	}
+
+	env := buildAWSEnv(awsCfg, creds)
+
+	counts := map[string]int{}
+	values := map[string]string{}
+	for _, e := range env {
+		for _, key := range []string{"AWS_REGION", "AWS_DEFAULT_REGION", "AWS_PROFILE", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"} {
+			if strings.HasPrefix(e, key+"=") {
+				counts[key]++
+				if counts[key] == 1 {
+					values[key] = e[len(key)+1:]
+				}
+			}
+		}
+	}
+
+	for _, key := range []string{"AWS_REGION", "AWS_DEFAULT_REGION", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"} {
+		if counts[key] != 1 {
+			t.Errorf("%s: expected exactly 1 occurrence, got %d", key, counts[key])
+		}
+	}
+	if values["AWS_REGION"] != "eu-west-1" {
+		t.Errorf("AWS_REGION: got %q, want %q", values["AWS_REGION"], "eu-west-1")
+	}
+	if values["AWS_ACCESS_KEY_ID"] != "CTX_KEY_ID" {
+		t.Errorf("AWS_ACCESS_KEY_ID: got %q, want %q", values["AWS_ACCESS_KEY_ID"], "CTX_KEY_ID")
+	}
+	if values["AWS_SECRET_ACCESS_KEY"] != "CTX_SECRET" {
+		t.Errorf("AWS_SECRET_ACCESS_KEY: got %q, want %q", values["AWS_SECRET_ACCESS_KEY"], "CTX_SECRET")
+	}
+	if counts["AWS_PROFILE"] != 0 {
+		t.Errorf("AWS_PROFILE should not appear when vault creds are used, got %d occurrences", counts["AWS_PROFILE"])
 	}
 }
 

--- a/internal/cli/use.go
+++ b/internal/cli/use.go
@@ -242,9 +242,11 @@ func switchContext(mgr *config.Manager, ctx *config.ContextConfig) ([]string, er
 		}
 	}
 
-	// Start auto-connect tunnels
+	// Start auto-connect tunnels (SSH or SSM)
 	var failedTunnels []string
-	if len(ctx.Tunnels) > 0 && ctx.SSH != nil && ctx.SSH.Bastion.Host != "" {
+	hasSSHAutoConnect := ctx.SSH != nil && ctx.SSH.Bastion.Host != "" && len(ctx.Tunnels) > 0
+	hasSSMAutoConnect := ctx.AWS != nil && len(ctx.AWS.Tunnels) > 0
+	if hasSSHAutoConnect || hasSSMAutoConnect {
 		var err error
 		_, failedTunnels, err = startAutoConnectTunnels(mgr, ctx)
 		if err != nil {

--- a/internal/cli/use.go
+++ b/internal/cli/use.go
@@ -244,7 +244,7 @@ func switchContext(mgr *config.Manager, ctx *config.ContextConfig) ([]string, er
 
 	// Start auto-connect tunnels
 	var failedTunnels []string
-	if len(ctx.Tunnels) > 0 && ctx.SSH != nil && ctx.SSH.Bastion.Host != "" {
+	if len(ctx.Tunnels) > 0 {
 		var err error
 		_, failedTunnels, err = startAutoConnectTunnels(mgr, ctx)
 		if err != nil {

--- a/internal/config/context.go
+++ b/internal/config/context.go
@@ -343,6 +343,7 @@ func ValidateContext(ctx *ContextConfig) error {
 	}
 
 	// Validate tunnels
+	hasSSHTunnels := false
 	for i, t := range ctx.Tunnels {
 		if t.Name == "" {
 			return fmt.Errorf("tunnel %d: name is required", i)
@@ -356,13 +357,18 @@ func ValidateContext(ctx *ContextConfig) error {
 		if t.LocalPort <= 0 || t.LocalPort > 65535 {
 			return fmt.Errorf("tunnel %s: invalid local_port %d", t.Name, t.LocalPort)
 		}
+		if t.Type == "aws" {
+			if t.Target == "" {
+				return fmt.Errorf("tunnel %s: target is required for type aws", t.Name)
+			}
+		} else {
+			hasSSHTunnels = true
+		}
 	}
 
-	// If tunnels are defined, SSH bastion should be configured
-	if len(ctx.Tunnels) > 0 {
-		if ctx.SSH == nil || ctx.SSH.Bastion.Host == "" {
-			return fmt.Errorf("SSH bastion must be configured when tunnels are defined")
-		}
+	// SSH bastion is required only for SSH tunnels (type: aws tunnels use IAM credentials)
+	if hasSSHTunnels && (ctx.SSH == nil || ctx.SSH.Bastion.Host == "") {
+		return fmt.Errorf("SSH bastion must be configured when SSH tunnels are defined")
 	}
 
 	// Validate secret files

--- a/internal/config/context_test.go
+++ b/internal/config/context_test.go
@@ -250,6 +250,42 @@ func TestValidateContext(t *testing.T) {
 			errMsg:  "SSH bastion must be configured",
 		},
 		{
+			name: "aws tunnel without bastion is valid",
+			ctx: &ContextConfig{
+				Name: "test",
+				AWS:  &AWSConfig{Profile: "my-profile", Region: "eu-west-1"},
+				Tunnels: []TunnelConfig{
+					{
+						Name:       "postgres",
+						Type:       "aws",
+						Target:     "i-0abc123def456789a",
+						RemoteHost: "db.internal.vpc",
+						RemotePort: 5432,
+						LocalPort:  5432,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "aws tunnel missing target",
+			ctx: &ContextConfig{
+				Name: "test",
+				AWS:  &AWSConfig{Profile: "my-profile", Region: "eu-west-1"},
+				Tunnels: []TunnelConfig{
+					{
+						Name:       "postgres",
+						Type:       "aws",
+						RemoteHost: "db.internal.vpc",
+						RemotePort: 5432,
+						LocalPort:  5432,
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "target is required for type aws",
+		},
+		{
 			name: "valid AKS config",
 			ctx: &ContextConfig{
 				Name: "test",

--- a/internal/config/types_definitions.go
+++ b/internal/config/types_definitions.go
@@ -37,11 +37,12 @@ const (
 
 // AWSConfig holds AWS-specific configuration.
 type AWSConfig struct {
-	Config   string `yaml:"config,omitempty" mapstructure:"config"`
-	Profile  string `yaml:"profile" mapstructure:"profile"`
-	Region   string `yaml:"region" mapstructure:"region"`
-	UseVault bool   `yaml:"use_vault" mapstructure:"use_vault"`
-	SSOLogin bool   `yaml:"sso_login,omitempty" mapstructure:"sso_login"`
+	Config   string            `yaml:"config,omitempty" mapstructure:"config"`
+	Profile  string            `yaml:"profile" mapstructure:"profile"`
+	Region   string            `yaml:"region" mapstructure:"region"`
+	UseVault bool              `yaml:"use_vault" mapstructure:"use_vault"`
+	SSOLogin bool              `yaml:"sso_login,omitempty" mapstructure:"sso_login"`
+	Tunnels  []SSMTunnelConfig `yaml:"tunnels,omitempty" mapstructure:"tunnels"`
 }
 
 // GCPConfig holds GCP-specific configuration.
@@ -128,6 +129,17 @@ type SSHConfig struct {
 type TunnelConfig struct {
 	Name        string `yaml:"name" mapstructure:"name"`
 	Description string `yaml:"description" mapstructure:"description"`
+	RemoteHost  string `yaml:"remote_host" mapstructure:"remote_host"`
+	RemotePort  int    `yaml:"remote_port" mapstructure:"remote_port"`
+	LocalPort   int    `yaml:"local_port" mapstructure:"local_port"`
+	AutoConnect bool   `yaml:"auto_connect,omitempty" mapstructure:"auto_connect"`
+}
+
+// SSMTunnelConfig holds configuration for an AWS SSM port-forwarding tunnel.
+type SSMTunnelConfig struct {
+	Name        string `yaml:"name" mapstructure:"name"`
+	Description string `yaml:"description,omitempty" mapstructure:"description"`
+	SSMTarget   string `yaml:"ssm_target" mapstructure:"ssm_target"`
 	RemoteHost  string `yaml:"remote_host" mapstructure:"remote_host"`
 	RemotePort  int    `yaml:"remote_port" mapstructure:"remote_port"`
 	LocalPort   int    `yaml:"local_port" mapstructure:"local_port"`

--- a/internal/config/types_definitions.go
+++ b/internal/config/types_definitions.go
@@ -125,9 +125,13 @@ type SSHConfig struct {
 }
 
 // TunnelConfig holds configuration for a single tunnel.
+// Type selects the transport: empty or "ssh" uses the SSH bastion; "aws" uses AWS SSM Session Manager.
+// Target is required for type "aws" and holds the EC2 instance ID (i-xxxxxxxxxxxxxxxxx).
 type TunnelConfig struct {
 	Name        string `yaml:"name" mapstructure:"name"`
 	Description string `yaml:"description" mapstructure:"description"`
+	Type        string `yaml:"type,omitempty" mapstructure:"type"`
+	Target      string `yaml:"target,omitempty" mapstructure:"target"`
 	RemoteHost  string `yaml:"remote_host" mapstructure:"remote_host"`
 	RemotePort  int    `yaml:"remote_port" mapstructure:"remote_port"`
 	LocalPort   int    `yaml:"local_port" mapstructure:"local_port"`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,7 +57,7 @@ nav:
       - Cloud Secrets: secrets/cloud.md
   - Features:
       - VPN: features/vpn.md
-      - SSH Tunnels: features/tunnels.md
+      - Tunnels: features/tunnels.md
       - Browser Profiles: features/browser.md
       - Editor/IDE: features/editor.md
       - Proxy: features/proxy.md


### PR DESCRIPTION
# feat(tunnel): AWS SSM tunnel support via Session Manager

## What

Adds port-forwarding tunnels to VPC resources via [AWS Session Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager.html) — no open SSH port, no bastion key, just IAM credentials.

AWS tunnels are configured under `tunnels:` alongside SSH tunnels, using `type: aws` to distinguish them:

```yaml
aws:
  profile: myproject-prod
  region: eu-west-1
  sso_login: true

tunnels:
  - name: postgres
    type: aws
    target: i-0abc123def456789a   # EC2 instance ID
    remote_host: db.internal.vpc
    remote_port: 5432
    local_port: 5432
    auto_connect: true

  - name: legacy-db              # SSH tunnel — no type, behaviour unchanged
    remote_host: db.internal
    remote_port: 5432
    local_port: 5433
```

## Why

The SSH bastion approach requires an open port 22 and key management — SSM removes both requirements and works anywhere the instance has the SSM Agent running and the right IAM profile attached.

## How it works

- `ctx tunnel up` / `ctx tunnel down` / `ctx tunnel list` / `ctx tunnel status` handle both SSH and AWS tunnels transparently (TYPE column shows `ssh` or `aws`)
- AWS tunnels run as `aws ssm start-session` subprocesses with AWS credentials injected explicitly into the environment — this makes `auto_connect` work correctly before the shell hook sources the env file
- On stop, SIGTERM is sent to the **entire process group** (`Kill(-pid, SIGTERM)`), not just the `aws` PID — this ensures `session-manager-plugin` (spawned as a child) is also terminated
- Before starting interactively, ctx calls `aws ssm describe-instance-information` to validate the target instance is registered in SSM and gives a clear error if not
- `ctx logout` and `ctx deactivate` stop AWS tunnels alongside SSH tunnels
- Context validation accepts `tunnels:` with `type: aws` without requiring an SSH bastion; SSH tunnels still require one

## Requirements to test

On the EC2 instance:
- SSM Agent installed and running
- IAM instance profile with `AmazonSSMManagedInstanceCore`
- No inbound security group rules needed

On your local machine:
- [AWS CLI v2](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
- [session-manager-plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html) in PATH

## Checklist

- [x] `go test ./...` — all passing (13 new tests in `tunnel_ssm_test.go`, 2 new in `context_test.go`)
- [x] `golangci-lint run` — no new warnings
- [x] `reuse lint` — compliant
- [x] `go build ./...` — clean
- [x] Docs updated: `docs/features/tunnels.md`, `docs/cloud/aws.md`
- [x] Example updated: `examples/aws-sso.yaml`
- [x] Nav updated: `mkdocs.yml`

## Files changed

| File | Change |
|------|--------|
| `internal/config/types_definitions.go` | Add `Type` and `Target` fields to `TunnelConfig`; remove `SSMTunnelConfig` and `aws.tunnels` |
| `internal/config/context.go` | Validation: SSH bastion required only for SSH tunnels; `target` required for `type: aws` |
| `internal/config/context_test.go` | 2 new validation tests for AWS tunnels |
| `internal/cli/tunnel.go` | AWS tunnel lifecycle, unified loops, process group kill, config-change detection |
| `internal/cli/tunnel_ssm_test.go` | New file — 13 tests |
| `internal/cli/use.go` | Auto-connect guard simplified |
| `internal/cli/deactivate.go` | Stop AWS tunnels on deactivate |
| `internal/cli/logout.go` | Stop AWS tunnels on logout |
| `docs/features/tunnels.md` | Full AWS tunnels section |
| `docs/cloud/aws.md` | AWS tunnels summary + link |
| `examples/aws-sso.yaml` | AWS tunnels example |
| `mkdocs.yml` | Nav label: "SSH Tunnels" → "Tunnels" |

---

<details>
<summary>Design notes</summary>

## Use case

Connect from localhost to resources inside an AWS VPC (RDS, ElastiCache, internal services) through an EC2 bastion instance using **AWS SSM Session Manager** — no port 22, no SSH keys, just IAM credentials and the `session-manager-plugin`.

The bastion is an EC2 instance with:
- SSM Agent installed and running
- IAM instance profile with `AmazonSSMManagedInstanceCore`
- No inbound security group rules (only HTTPS outbound to SSM endpoints)

## Design decision: `tunnels:` with `type: aws`

AWS tunnels live under `tunnels:` alongside SSH tunnels. A `type: aws` field selects the transport; omitting `type` (or leaving it empty) keeps the existing SSH behaviour. This keeps the config coherent — all tunnel definitions in one place, regardless of transport.

The `target` field holds the EC2 instance ID (`i-xxxxxxxxxxxxxxxxx`). Future cloud providers (GCP IAP, Azure Bastion) would use the same `target` field with their own value format, each identified by their own `type`.

## `auto_connect` credential problem

When ctx starts tunnels with `auto_connect: true`, it does so **before** the shell hook has sourced the env file. At that point `os.Environ()` still holds the previous context's environment. The fix is to build `cmd.Env` explicitly, injecting AWS credentials directly — the same approach `secrets.go` uses for other AWS calls.

## Killing the entire process group

`aws ssm start-session` spawns `session-manager-plugin` as a child process. Sending SIGTERM only to the `aws` PID leaves the plugin alive. Since subprocesses are started with `Setsid: true`, the PGID equals the `aws` PID — `syscall.Kill(-pid, SIGTERM)` kills both.

</details>

---

## A note on transparency

This is my **first open source contribution**. I use ctx daily and the SSM tunnel feature was a personal itch — I rely on it to connect to VPC databases without maintaining SSH keys or opening bastion ports.

I don't write Go professionally, so this contribution was built with the assistance of [Claude Code](https://claude.com/claude-code) (Anthropic's AI coding assistant). I want to be upfront about that. What I did bring: the use case, the architectural decisions (debated and validated with the maintainer), hands-on functional testing against a real AWS environment, and the judgment calls throughout — including adapting the design after maintainer feedback to place tunnels under `tunnels:` rather than `aws.tunnels`.

I believe the code is solid and the approach is consistent with the repo's patterns, but I welcome any feedback — especially from Go experts who spot things I missed.