### PR TITLE
feat(tunnel): add CloudFormation target resolution for AWS SSM tunnels

### DIFF
--- a/docs/features/tunnels.md
+++ b/docs/features/tunnels.md
@@ -219,7 +219,11 @@ AWS tunnels use [AWS Session Manager](https://docs.aws.amazon.com/systems-manage
 
 ### Configuration
 
-AWS tunnels live under `tunnels:` alongside SSH tunnels, distinguished by `type: aws`:
+AWS tunnels live under `tunnels:` alongside SSH tunnels, distinguished by `type: aws`.
+
+The `target` field accepts three forms:
+
+**1. Literal EC2 instance ID** (static, backward-compatible):
 
 ```yaml
 aws:
@@ -235,14 +239,38 @@ tunnels:
     remote_port: 5432
     local_port: 5432
     auto_connect: true
-
-  - name: redis
-    type: aws
-    target: i-0abc123def456789a
-    remote_host: cache.internal.vpc
-    remote_port: 6379
-    local_port: 6379
 ```
+
+**2. CloudFormation Export** — resolves the instance ID from a named CF Export at tunnel start:
+
+```yaml
+tunnels:
+  - name: postgres
+    type: aws
+    target:
+      export: MyStack-BastionInstanceId   # CloudFormation Export name
+    remote_host: db.internal.vpc
+    remote_port: 5432
+    local_port: 5432
+    auto_connect: true
+```
+
+**3. CloudFormation Stack Output** — resolves the instance ID from a specific stack output:
+
+```yaml
+tunnels:
+  - name: postgres
+    type: aws
+    target:
+      stack: my-infra                     # CloudFormation stack name
+      output: BastionInstanceId           # Output key in that stack
+    remote_host: db.internal.vpc
+    remote_port: 5432
+    local_port: 5432
+    auto_connect: true
+```
+
+For both CloudFormation forms, ctx executes the appropriate AWS CLI command before opening the tunnel. If the export or output does not exist, a warning is emitted and the tunnel is skipped.
 
 ### Tunnel Options
 
@@ -251,11 +279,26 @@ tunnels:
 | `name` | string | **Required.** Tunnel identifier |
 | `description` | string | Human-readable description |
 | `type` | string | `aws` for AWS Session Manager tunnels; omit or leave empty for SSH |
-| `target` | string | **Required for `type: aws`.** EC2 instance ID (`i-xxxxxxxxxxxxxxxxx`) |
+| `target` | string \| object | **Required for `type: aws`.** Literal EC2 instance ID, `{export: <name>}`, or `{stack: <name>, output: <key>}` |
 | `remote_host` | string | **Required.** Remote host inside the VPC |
 | `remote_port` | int | **Required.** Remote port |
 | `local_port` | int | **Required.** Local port to bind |
 | `auto_connect` | bool | Start automatically on context switch |
+
+### IAM Permissions for CloudFormation Resolution
+
+When using `export` or `stack`+`output` target forms, the IAM principal used by the context needs additional permissions:
+
+```json
+{
+  "Effect": "Allow",
+  "Action": [
+    "cloudformation:ListExports",
+    "cloudformation:DescribeStacks"
+  ],
+  "Resource": "*"
+}
+```
 
 ### Commands
 

--- a/examples/aws-tunnel-cf-target.yaml
+++ b/examples/aws-tunnel-cf-target.yaml
@@ -1,0 +1,49 @@
+# Example: AWS SSM tunnels with CloudFormation target resolution
+#
+# ctx can resolve the EC2 bastion instance ID dynamically from CloudFormation
+# instead of hardcoding it. Useful when infrastructure is recreated regularly.
+#
+# Three forms are supported for `target`:
+#   1. Literal string      — target: i-0abc123def456789a
+#   2. CloudFormation Export  — target: {export: ExportName}
+#   3. Stack Output        — target: {stack: StackName, output: OutputKey}
+
+name: myproject-prod
+environment: production
+description: Production context with CF-resolved tunnel targets
+
+aws:
+  profile: myproject-prod
+  region: eu-west-1
+  sso_login: true
+
+tunnels:
+  # Literal EC2 instance ID (backward-compatible, no extra AWS call)
+  - name: redis
+    type: aws
+    target: i-0abc123def456789a
+    remote_host: cache.internal.vpc
+    remote_port: 6379
+    local_port: 6379
+
+  # Resolved from a CloudFormation Export at tunnel start time
+  # Requires cloudformation:ListExports permission
+  - name: postgres
+    type: aws
+    target:
+      export: MyStack-BastionInstanceId
+    remote_host: db.internal.vpc
+    remote_port: 5432
+    local_port: 5432
+    auto_connect: true
+
+  # Resolved from a CloudFormation Stack Output at tunnel start time
+  # Requires cloudformation:DescribeStacks permission
+  - name: opensearch
+    type: aws
+    target:
+      stack: myproject-prod-infra
+      output: BastionInstanceId
+    remote_host: opensearch.internal.vpc
+    remote_port: 9200
+    local_port: 9200

--- a/internal/cli/tunnel.go
+++ b/internal/cli/tunnel.go
@@ -250,6 +250,11 @@ func runTunnelUp(cmd *cobra.Command, args []string) error {
 				continue
 			}
 
+			if err := validateTunnelTarget(t.Name, t.Target); err != nil {
+				yellow.Printf("⚠ %s\n", err)
+				continue
+			}
+
 			if entry, exists := state.TunnelPIDs[t.Name]; exists {
 				if isProcessRunning(entry.PID) {
 					configChanged := entry.Config.Target != t.Target ||
@@ -270,12 +275,18 @@ func runTunnelUp(cmd *cobra.Command, args []string) error {
 			tunnelConfig := t
 			tunnelConfig.LocalPort = actualPort
 
-			if err := validateSSMTarget(tunnelConfig.Target, awsEnv); err != nil {
+			resolvedID, err := resolveAWSTarget(tunnelConfig.Target, awsEnv)
+			if err != nil {
 				yellow.Printf("⚠ %s: %v\n", t.Name, err)
 				continue
 			}
 
-			ssmArgs := buildSSMArgs(tunnelConfig)
+			if err := validateSSMTarget(resolvedID, awsEnv); err != nil {
+				yellow.Printf("⚠ %s: %v\n", t.Name, err)
+				continue
+			}
+
+			ssmArgs := buildSSMArgs(resolvedID, tunnelConfig)
 			cmd := exec.Command("aws", ssmArgs...)
 			cmd.Env = awsEnv
 			cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
@@ -497,17 +508,120 @@ func buildAWSEnv(awsCfg *config.AWSConfig, awsCreds *config.AWSCredentials) []st
 }
 
 // buildSSMArgs builds the aws ssm start-session arguments for port forwarding to a remote host.
-func buildSSMArgs(tunnel config.TunnelConfig) []string {
+// instanceID must already be a resolved EC2 instance ID string.
+func buildSSMArgs(instanceID string, tunnel config.TunnelConfig) []string {
 	params := fmt.Sprintf(
 		`{"host":["%s"],"portNumber":["%d"],"localPortNumber":["%d"]}`,
 		tunnel.RemoteHost, tunnel.RemotePort, tunnel.LocalPort,
 	)
 	return []string{
 		"ssm", "start-session",
-		"--target", tunnel.Target,
+		"--target", instanceID,
 		"--document-name", "AWS-StartPortForwardingSessionToRemoteHost",
 		"--parameters", params,
 	}
+}
+
+// validateTunnelTarget checks the target config for an AWS tunnel before attempting to
+// start it. Returns a descriptive error so callers can emit a warning and skip.
+func validateTunnelTarget(tunnelName string, target config.TunnelTarget) error {
+	if target.IsEmpty() {
+		return fmt.Errorf("%s: target is required for type aws — skipping", tunnelName)
+	}
+	if target.Kind == config.TunnelTargetKindInvalid {
+		return fmt.Errorf("%s: invalid target format — expected string, {export: ...}, or {stack: ..., output: ...} — skipping", tunnelName)
+	}
+	if target.Kind == config.TunnelTargetKindStackOutput && target.Output == "" {
+		return fmt.Errorf("%s: target.stack requires target.output (got empty — check for typos like 'outputs') — skipping", tunnelName)
+	}
+	return nil
+}
+
+// resolveAWSTarget resolves the EC2 instance ID from a TunnelTarget.
+// For literal targets it returns the ID immediately; for CloudFormation references
+// it executes the appropriate aws cloudformation CLI command.
+func resolveAWSTarget(target config.TunnelTarget, awsEnv []string) (string, error) {
+	switch target.Kind {
+	case config.TunnelTargetKindLiteral:
+		return target.Literal, nil
+	case config.TunnelTargetKindExport:
+		return resolveCFExport(target.Export, awsEnv)
+	case config.TunnelTargetKindStackOutput:
+		return resolveCFStackOutput(target.Stack, target.Output, awsEnv)
+	default:
+		return "", fmt.Errorf("invalid target format — expected string, {export: ...}, or {stack: ..., output: ...}")
+	}
+}
+
+// resolveCFExport fetches the value of a CloudFormation Export by name.
+// It pages through all results using NextToken to handle accounts with many exports.
+func resolveCFExport(exportName string, awsEnv []string) (string, error) {
+	nextToken := ""
+	for {
+		args := []string{"cloudformation", "list-exports", "--output", "json"}
+		if nextToken != "" {
+			args = append(args, "--next-token", nextToken)
+		}
+		cmd := exec.Command("aws", args...)
+		cmd.Env = awsEnv
+		out, err := cmd.Output()
+		if err != nil {
+			return "", fmt.Errorf("failed to list CloudFormation exports: %w", err)
+		}
+		// result is declared inside the loop so NextToken is zero-initialised on each
+		// iteration — json.Unmarshal only sets fields present in the response JSON.
+		var result struct {
+			Exports []struct {
+				Name  string `json:"Name"`
+				Value string `json:"Value"`
+			} `json:"Exports"`
+			NextToken string `json:"NextToken"`
+		}
+		if err := json.Unmarshal(out, &result); err != nil {
+			return "", fmt.Errorf("failed to parse CloudFormation exports response: %w", err)
+		}
+		for _, e := range result.Exports {
+			if e.Name == exportName {
+				return e.Value, nil
+			}
+		}
+		if result.NextToken == "" {
+			break
+		}
+		nextToken = result.NextToken
+	}
+	return "", fmt.Errorf("CloudFormation export %q not found", exportName)
+}
+
+// resolveCFStackOutput fetches an OutputValue from a CloudFormation Stack.
+func resolveCFStackOutput(stackName, outputKey string, awsEnv []string) (string, error) {
+	cmd := exec.Command("aws", "cloudformation", "describe-stacks",
+		"--stack-name", stackName, "--output", "json")
+	cmd.Env = awsEnv
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("CloudFormation stack %q not found or has no outputs: %w", stackName, err)
+	}
+	var result struct {
+		Stacks []struct {
+			Outputs []struct {
+				OutputKey   string `json:"OutputKey"`
+				OutputValue string `json:"OutputValue"`
+			} `json:"Outputs"`
+		} `json:"Stacks"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		return "", fmt.Errorf("failed to parse CloudFormation stacks response: %w", err)
+	}
+	if len(result.Stacks) == 0 {
+		return "", fmt.Errorf("CloudFormation stack %q not found or has no outputs", stackName)
+	}
+	for _, o := range result.Stacks[0].Outputs {
+		if o.OutputKey == outputKey {
+			return o.OutputValue, nil
+		}
+	}
+	return "", fmt.Errorf("output key %q not found in stack %q", outputKey, stackName)
 }
 
 // validateSSMTarget checks that the given EC2 instance ID is registered in SSM.
@@ -809,6 +923,12 @@ func startAutoConnectTunnels(mgr *config.Manager, ctx *config.ContextConfig) ([]
 				continue
 			}
 
+			if err := validateTunnelTarget(t.Name, t.Target); err != nil {
+				yellow.Fprintf(os.Stderr, "⚠ %s\n", err)
+				failedTunnels = append(failedTunnels, t.Name)
+				continue
+			}
+
 			if entry, exists := state.TunnelPIDs[t.Name]; exists {
 				if isProcessRunning(entry.PID) {
 					configChanged := entry.Config.Target != t.Target ||
@@ -828,7 +948,14 @@ func startAutoConnectTunnels(mgr *config.Manager, ctx *config.ContextConfig) ([]
 			tunnelConfig := t
 			tunnelConfig.LocalPort = actualPort
 
-			ssmArgs := buildSSMArgs(tunnelConfig)
+			resolvedID, err := resolveAWSTarget(tunnelConfig.Target, awsEnv)
+			if err != nil {
+				yellow.Fprintf(os.Stderr, "⚠ Tunnel %s: %v\n", t.Name, err)
+				failedTunnels = append(failedTunnels, t.Name)
+				continue
+			}
+
+			ssmArgs := buildSSMArgs(resolvedID, tunnelConfig)
 			cmd := exec.Command("aws", ssmArgs...)
 			cmd.Env = awsEnv
 			cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}

--- a/internal/cli/tunnel_ssm_test.go
+++ b/internal/cli/tunnel_ssm_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Enrique Alonso <enrialonso@gmail.com>
+// SPDX-FileCopyrightText: 2026 Vedran Lebo <vedran@flyingpenguin.tech>
 // SPDX-License-Identifier: MIT
 
 package cli
@@ -66,13 +66,13 @@ func TestBuildSSMArgs(t *testing.T) {
 	tunnel := config.TunnelConfig{
 		Name:       "postgres",
 		Type:       "aws",
-		Target:     "i-0abc123def456789a",
+		Target:     config.TunnelTarget{Kind: config.TunnelTargetKindLiteral, Literal: "i-0abc123def456789a"},
 		RemoteHost: "db.internal.vpc",
 		RemotePort: 5432,
 		LocalPort:  5432,
 	}
 
-	args := buildSSMArgs(tunnel)
+	args := buildSSMArgs("i-0abc123def456789a", tunnel)
 
 	expected := []string{
 		"ssm", "start-session",
@@ -94,13 +94,13 @@ func TestBuildSSMArgs(t *testing.T) {
 func TestBuildSSMArgs_PortSubstitution(t *testing.T) {
 	tunnel := config.TunnelConfig{
 		Type:       "aws",
-		Target:     "i-0abc123def456789a",
+		Target:     config.TunnelTarget{Kind: config.TunnelTargetKindLiteral, Literal: "i-0abc123def456789a"},
 		RemoteHost: "cache.internal",
 		RemotePort: 6379,
 		LocalPort:  16379, // remapped port
 	}
 
-	args := buildSSMArgs(tunnel)
+	args := buildSSMArgs("i-0abc123def456789a", tunnel)
 
 	// Find --parameters arg
 	var params string
@@ -289,6 +289,183 @@ func TestBuildAWSEnv_HostVarsAreFiltered(t *testing.T) {
 	}
 }
 
+// --- resolveAWSTarget tests ---
+
+// fakeAWSBin writes a shell script at <tmpDir>/aws that prints the given JSON output and exits 0.
+func fakeAWSBin(t *testing.T, tmpDir, responseJSON string) []string {
+	t.Helper()
+	script := fmt.Sprintf("#!/bin/sh\necho '%s'\n", responseJSON)
+	if err := os.WriteFile(filepath.Join(tmpDir, "aws"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return append(os.Environ(), "PATH="+tmpDir)
+}
+
+// fakeAWSBinFail writes a shell script at <tmpDir>/aws that exits non-zero.
+func fakeAWSBinFail(t *testing.T, tmpDir string) []string {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(tmpDir, "aws"), []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return append(os.Environ(), "PATH="+tmpDir)
+}
+
+func TestResolveAWSTarget_Literal(t *testing.T) {
+	target := config.TunnelTarget{Kind: config.TunnelTargetKindLiteral, Literal: "i-0abc123def456789a"}
+	got, err := resolveAWSTarget(target, os.Environ())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "i-0abc123def456789a" {
+		t.Errorf("got %q, want %q", got, "i-0abc123def456789a")
+	}
+}
+
+func TestResolveAWSTarget_Export_Found(t *testing.T) {
+	tmpDir := t.TempDir()
+	response := map[string]any{
+		"Exports": []map[string]string{
+			{"Name": "MyStack-BastionInstanceId", "Value": "i-0abc123def456789a"},
+		},
+	}
+	out, _ := json.Marshal(response)
+	awsEnv := fakeAWSBin(t, tmpDir, string(out))
+	t.Setenv("PATH", tmpDir)
+
+	target := config.TunnelTarget{Kind: config.TunnelTargetKindExport, Export: "MyStack-BastionInstanceId"}
+	got, err := resolveAWSTarget(target, awsEnv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "i-0abc123def456789a" {
+		t.Errorf("got %q, want %q", got, "i-0abc123def456789a")
+	}
+}
+
+func TestResolveAWSTarget_Export_Paginated(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// First page returns no match but includes NextToken; second page (--next-token arg) has the export.
+	// Uses only shell builtins (case/$*) so the script works even when PATH=tmpDir only.
+	script := `#!/bin/sh
+case "$*" in
+  *--next-token*)
+    echo '{"Exports":[{"Name":"MyStack-BastionInstanceId","Value":"i-0abc123def456789a"}]}'
+    ;;
+  *)
+    echo '{"Exports":[{"Name":"OtherExport","Value":"i-other"}],"NextToken":"page2"}'
+    ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "aws"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", tmpDir)
+	awsEnv := os.Environ()
+
+	target := config.TunnelTarget{Kind: config.TunnelTargetKindExport, Export: "MyStack-BastionInstanceId"}
+	got, err := resolveAWSTarget(target, awsEnv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "i-0abc123def456789a" {
+		t.Errorf("got %q, want %q", got, "i-0abc123def456789a")
+	}
+}
+
+func TestResolveAWSTarget_Export_NotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	response := map[string]any{"Exports": []any{}}
+	out, _ := json.Marshal(response)
+	awsEnv := fakeAWSBin(t, tmpDir, string(out))
+	t.Setenv("PATH", tmpDir)
+
+	target := config.TunnelTarget{Kind: config.TunnelTargetKindExport, Export: "NonExistent-Export"}
+	_, err := resolveAWSTarget(target, awsEnv)
+	if err == nil {
+		t.Fatal("expected error for missing export, got nil")
+	}
+}
+
+func TestResolveAWSTarget_Export_AWSFails(t *testing.T) {
+	tmpDir := t.TempDir()
+	awsEnv := fakeAWSBinFail(t, tmpDir)
+	t.Setenv("PATH", tmpDir)
+
+	target := config.TunnelTarget{Kind: config.TunnelTargetKindExport, Export: "MyStack-BastionInstanceId"}
+	_, err := resolveAWSTarget(target, awsEnv)
+	if err == nil {
+		t.Fatal("expected error when aws CLI fails, got nil")
+	}
+}
+
+func TestResolveAWSTarget_StackOutput_Found(t *testing.T) {
+	tmpDir := t.TempDir()
+	response := map[string]any{
+		"Stacks": []map[string]any{
+			{
+				"Outputs": []map[string]string{
+					{"OutputKey": "BastionInstanceId", "OutputValue": "i-0abc123def456789a"},
+				},
+			},
+		},
+	}
+	out, _ := json.Marshal(response)
+	awsEnv := fakeAWSBin(t, tmpDir, string(out))
+	t.Setenv("PATH", tmpDir)
+
+	target := config.TunnelTarget{Kind: config.TunnelTargetKindStackOutput, Stack: "my-infra", Output: "BastionInstanceId"}
+	got, err := resolveAWSTarget(target, awsEnv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "i-0abc123def456789a" {
+		t.Errorf("got %q, want %q", got, "i-0abc123def456789a")
+	}
+}
+
+func TestResolveAWSTarget_StackOutput_StackNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	awsEnv := fakeAWSBinFail(t, tmpDir)
+	t.Setenv("PATH", tmpDir)
+
+	target := config.TunnelTarget{Kind: config.TunnelTargetKindStackOutput, Stack: "nonexistent-stack", Output: "BastionInstanceId"}
+	_, err := resolveAWSTarget(target, awsEnv)
+	if err == nil {
+		t.Fatal("expected error when stack not found, got nil")
+	}
+}
+
+func TestResolveAWSTarget_StackOutput_OutputKeyNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	response := map[string]any{
+		"Stacks": []map[string]any{
+			{
+				"Outputs": []map[string]string{
+					{"OutputKey": "OtherKey", "OutputValue": "i-0abc123def456789a"},
+				},
+			},
+		},
+	}
+	out, _ := json.Marshal(response)
+	awsEnv := fakeAWSBin(t, tmpDir, string(out))
+	t.Setenv("PATH", tmpDir)
+
+	target := config.TunnelTarget{Kind: config.TunnelTargetKindStackOutput, Stack: "my-infra", Output: "BastionInstanceId"}
+	_, err := resolveAWSTarget(target, awsEnv)
+	if err == nil {
+		t.Fatal("expected error for missing output key, got nil")
+	}
+}
+
+func TestResolveAWSTarget_InvalidKind(t *testing.T) {
+	target := config.TunnelTarget{Kind: config.TunnelTargetKindInvalid}
+	_, err := resolveAWSTarget(target, os.Environ())
+	if err == nil {
+		t.Fatal("expected error for invalid target kind, got nil")
+	}
+}
+
 // writeTunnelStateFile writes a tunnelState JSON file under stateDir/tunnels/<context>.json.
 func writeTunnelStateFile(t *testing.T, stateDir, contextName string, state *tunnelState) string {
 	t.Helper()
@@ -330,7 +507,7 @@ func TestStopContextTunnels_StopsAWSTunnels(t *testing.T) {
 				Config: config.TunnelConfig{
 					Name:       "postgres",
 					Type:       "aws",
-					Target:     "i-0abc123def456789a",
+					Target:     config.TunnelTarget{Kind: config.TunnelTargetKindLiteral, Literal: "i-0abc123def456789a"},
 					RemoteHost: "db.internal.vpc",
 					RemotePort: 5432,
 					LocalPort:  5432,

--- a/internal/config/context.go
+++ b/internal/config/context.go
@@ -357,11 +357,7 @@ func ValidateContext(ctx *ContextConfig) error {
 		if t.LocalPort <= 0 || t.LocalPort > 65535 {
 			return fmt.Errorf("tunnel %s: invalid local_port %d", t.Name, t.LocalPort)
 		}
-		if t.Type == "aws" {
-			if t.Target == "" {
-				return fmt.Errorf("tunnel %s: target is required for type aws", t.Name)
-			}
-		} else {
+		if t.Type != "aws" {
 			hasSSHTunnels = true
 		}
 	}

--- a/internal/config/context_test.go
+++ b/internal/config/context_test.go
@@ -258,7 +258,7 @@ func TestValidateContext(t *testing.T) {
 					{
 						Name:       "postgres",
 						Type:       "aws",
-						Target:     "i-0abc123def456789a",
+						Target:     TunnelTarget{Kind: TunnelTargetKindLiteral, Literal: "i-0abc123def456789a"},
 						RemoteHost: "db.internal.vpc",
 						RemotePort: 5432,
 						LocalPort:  5432,
@@ -268,7 +268,7 @@ func TestValidateContext(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "aws tunnel missing target",
+			name: "aws tunnel missing target is allowed (warn+skip at start time)",
 			ctx: &ContextConfig{
 				Name: "test",
 				AWS:  &AWSConfig{Profile: "my-profile", Region: "eu-west-1"},
@@ -282,8 +282,79 @@ func TestValidateContext(t *testing.T) {
 					},
 				},
 			},
-			wantErr: true,
-			errMsg:  "target is required for type aws",
+			wantErr: false,
+		},
+		{
+			name: "aws tunnel with export target is valid",
+			ctx: &ContextConfig{
+				Name: "test",
+				AWS:  &AWSConfig{Profile: "my-profile", Region: "eu-west-1"},
+				Tunnels: []TunnelConfig{
+					{
+						Name:       "postgres",
+						Type:       "aws",
+						Target:     TunnelTarget{Kind: TunnelTargetKindExport, Export: "MyStack-BastionInstanceId"},
+						RemoteHost: "db.internal.vpc",
+						RemotePort: 5432,
+						LocalPort:  5432,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "aws tunnel with stack output target is valid",
+			ctx: &ContextConfig{
+				Name: "test",
+				AWS:  &AWSConfig{Profile: "my-profile", Region: "eu-west-1"},
+				Tunnels: []TunnelConfig{
+					{
+						Name:       "postgres",
+						Type:       "aws",
+						Target:     TunnelTarget{Kind: TunnelTargetKindStackOutput, Stack: "my-infra", Output: "BastionInstanceId"},
+						RemoteHost: "db.internal.vpc",
+						RemotePort: 5432,
+						LocalPort:  5432,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "aws tunnel with invalid target object is allowed (warn+skip at start time)",
+			ctx: &ContextConfig{
+				Name: "test",
+				AWS:  &AWSConfig{Profile: "my-profile", Region: "eu-west-1"},
+				Tunnels: []TunnelConfig{
+					{
+						Name:       "postgres",
+						Type:       "aws",
+						Target:     TunnelTarget{Kind: TunnelTargetKindInvalid},
+						RemoteHost: "db.internal.vpc",
+						RemotePort: 5432,
+						LocalPort:  5432,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "aws tunnel with stack target missing output is allowed (warn+skip at start time)",
+			ctx: &ContextConfig{
+				Name: "test",
+				AWS:  &AWSConfig{Profile: "my-profile", Region: "eu-west-1"},
+				Tunnels: []TunnelConfig{
+					{
+						Name:       "postgres",
+						Type:       "aws",
+						Target:     TunnelTarget{Kind: TunnelTargetKindStackOutput, Stack: "my-infra"},
+						RemoteHost: "db.internal.vpc",
+						RemotePort: 5432,
+						LocalPort:  5432,
+					},
+				},
+			},
+			wantErr: false,
 		},
 		{
 			name: "valid AKS config",

--- a/internal/config/tunnel_target_test.go
+++ b/internal/config/tunnel_target_test.go
@@ -1,0 +1,154 @@
+// SPDX-FileCopyrightText: 2026 Vedran Lebo <vedran@flyingpenguin.tech>
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestTunnelTarget_UnmarshalYAML(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantKind  TunnelTargetKind
+		wantLit   string
+		wantExp   string
+		wantStack string
+		wantOut   string
+	}{
+		{
+			name:     "literal string",
+			input:    `target: i-0abc123def456789a`,
+			wantKind: TunnelTargetKindLiteral,
+			wantLit:  "i-0abc123def456789a",
+		},
+		{
+			name:    "export map",
+			input:   "target:\n  export: MyStack-BastionInstanceId\n",
+			wantKind: TunnelTargetKindExport,
+			wantExp: "MyStack-BastionInstanceId",
+		},
+		{
+			name:      "stack+output map",
+			input:     "target:\n  stack: my-infra\n  output: BastionInstanceId\n",
+			wantKind:  TunnelTargetKindStackOutput,
+			wantStack: "my-infra",
+			wantOut:   "BastionInstanceId",
+		},
+		{
+			name:     "invalid map (unrecognised keys)",
+			input:    "target:\n  bucket: my-bucket\n",
+			wantKind: TunnelTargetKindInvalid,
+		},
+		{
+			name:      "stack without output (caught at tunnel start time)",
+			input:     "target:\n  stack: my-infra\n",
+			wantKind:  TunnelTargetKindStackOutput,
+			wantStack: "my-infra",
+			wantOut:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out struct {
+				Target TunnelTarget `yaml:"target"`
+			}
+			if err := yaml.Unmarshal([]byte(tt.input), &out); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			got := out.Target
+			if got.Kind != tt.wantKind {
+				t.Errorf("Kind = %q, want %q", got.Kind, tt.wantKind)
+			}
+			if got.Literal != tt.wantLit {
+				t.Errorf("Literal = %q, want %q", got.Literal, tt.wantLit)
+			}
+			if got.Export != tt.wantExp {
+				t.Errorf("Export = %q, want %q", got.Export, tt.wantExp)
+			}
+			if got.Stack != tt.wantStack {
+				t.Errorf("Stack = %q, want %q", got.Stack, tt.wantStack)
+			}
+			if got.Output != tt.wantOut {
+				t.Errorf("Output = %q, want %q", got.Output, tt.wantOut)
+			}
+		})
+	}
+}
+
+func TestTunnelTarget_MarshalYAML(t *testing.T) {
+	tests := []struct {
+		name   string
+		target TunnelTarget
+		want   string
+	}{
+		{
+			name:   "literal round-trips as plain string",
+			target: TunnelTarget{Kind: TunnelTargetKindLiteral, Literal: "i-0abc123def456789a"},
+			want:   "target: i-0abc123def456789a\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := struct {
+				Target TunnelTarget `yaml:"target"`
+			}{Target: tt.target}
+			out, err := yaml.Marshal(in)
+			if err != nil {
+				t.Fatalf("marshal error: %v", err)
+			}
+			if string(out) != tt.want {
+				t.Errorf("got %q, want %q", string(out), tt.want)
+			}
+		})
+	}
+}
+
+func TestTunnelTarget_MarshalYAML_ExportRoundTrip(t *testing.T) {
+	in := struct {
+		Target TunnelTarget `yaml:"target"`
+	}{
+		Target: TunnelTarget{Kind: TunnelTargetKindExport, Export: "MyStack-BastionInstanceId"},
+	}
+	out, err := yaml.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	var roundTrip struct {
+		Target TunnelTarget `yaml:"target"`
+	}
+	if err := yaml.Unmarshal(out, &roundTrip); err != nil {
+		t.Fatalf("round-trip unmarshal error: %v", err)
+	}
+	if roundTrip.Target.Kind != TunnelTargetKindExport {
+		t.Errorf("round-trip Kind = %q, want %q", roundTrip.Target.Kind, TunnelTargetKindExport)
+	}
+	if roundTrip.Target.Export != "MyStack-BastionInstanceId" {
+		t.Errorf("round-trip Export = %q, want %q", roundTrip.Target.Export, "MyStack-BastionInstanceId")
+	}
+}
+
+func TestTunnelTarget_IsEmpty(t *testing.T) {
+	tests := []struct {
+		name   string
+		target TunnelTarget
+		want   bool
+	}{
+		{"zero value", TunnelTarget{}, true},
+		{"literal", TunnelTarget{Kind: TunnelTargetKindLiteral, Literal: "i-xxx"}, false},
+		{"export", TunnelTarget{Kind: TunnelTargetKindExport, Export: "my-export"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.target.IsEmpty(); got != tt.want {
+				t.Errorf("IsEmpty() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/config/types_definitions.go
+++ b/internal/config/types_definitions.go
@@ -5,9 +5,11 @@
 package config
 
 import (
+	"fmt"
 	"maps"
 
 	"dario.cat/mergo"
+	"gopkg.in/yaml.v3"
 )
 
 // Environment represents the deployment environment type (can be any string).
@@ -124,18 +126,89 @@ type SSHConfig struct {
 	TunnelTimeout     int           `yaml:"tunnel_timeout" mapstructure:"tunnel_timeout"` // seconds, default 5
 }
 
+// TunnelTargetKind describes how the EC2 instance ID for an AWS SSM tunnel is specified.
+type TunnelTargetKind string
+
+const (
+	TunnelTargetKindLiteral     TunnelTargetKind = "literal"
+	TunnelTargetKindExport      TunnelTargetKind = "export"
+	TunnelTargetKindStackOutput TunnelTargetKind = "stack_output"
+	TunnelTargetKindInvalid     TunnelTargetKind = "invalid"
+)
+
+// TunnelTarget holds the EC2 instance ID for an AWS SSM tunnel as a literal string,
+// a CloudFormation Export reference, or a CloudFormation Stack Output reference.
+type TunnelTarget struct {
+	Kind    TunnelTargetKind `json:"kind,omitempty"`
+	Literal string           `json:"literal,omitempty"`
+	Export  string           `json:"export,omitempty"`
+	Stack   string           `json:"stack,omitempty"`
+	Output  string           `json:"output,omitempty"`
+}
+
+// IsEmpty returns true when the target has not been set (zero value).
+func (t TunnelTarget) IsEmpty() bool {
+	return t.Kind == ""
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler, accepting either a scalar string
+// (literal EC2 instance ID) or a mapping with "export" or "stack"+"output" keys.
+func (t *TunnelTarget) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.ScalarNode:
+		t.Kind = TunnelTargetKindLiteral
+		t.Literal = value.Value
+		return nil
+	case yaml.MappingNode:
+		var m map[string]string
+		if err := value.Decode(&m); err != nil {
+			return fmt.Errorf("target: %w", err)
+		}
+		if export, ok := m["export"]; ok {
+			t.Kind = TunnelTargetKindExport
+			t.Export = export
+			return nil
+		}
+		if stack, ok := m["stack"]; ok {
+			t.Kind = TunnelTargetKindStackOutput
+			t.Stack = stack
+			t.Output = m["output"]
+			return nil
+		}
+		t.Kind = TunnelTargetKindInvalid
+		return nil
+	default:
+		return fmt.Errorf("target: expected string or mapping, got %v", value.Tag)
+	}
+}
+
+// MarshalYAML implements yaml.Marshaler, serialising back to the original compact form.
+func (t TunnelTarget) MarshalYAML() (interface{}, error) {
+	switch t.Kind {
+	case TunnelTargetKindLiteral:
+		return t.Literal, nil
+	case TunnelTargetKindExport:
+		return map[string]string{"export": t.Export}, nil
+	case TunnelTargetKindStackOutput:
+		return map[string]string{"stack": t.Stack, "output": t.Output}, nil
+	default:
+		return nil, nil
+	}
+}
+
 // TunnelConfig holds configuration for a single tunnel.
 // Type selects the transport: empty or "ssh" uses the SSH bastion; "aws" uses AWS SSM Session Manager.
-// Target is required for type "aws" and holds the EC2 instance ID (i-xxxxxxxxxxxxxxxxx).
+// Target is required for type "aws" and specifies the EC2 instance ID — either as a literal string,
+// a CloudFormation Export reference, or a CloudFormation Stack Output reference.
 type TunnelConfig struct {
-	Name        string `yaml:"name" mapstructure:"name"`
-	Description string `yaml:"description" mapstructure:"description"`
-	Type        string `yaml:"type,omitempty" mapstructure:"type"`
-	Target      string `yaml:"target,omitempty" mapstructure:"target"`
-	RemoteHost  string `yaml:"remote_host" mapstructure:"remote_host"`
-	RemotePort  int    `yaml:"remote_port" mapstructure:"remote_port"`
-	LocalPort   int    `yaml:"local_port" mapstructure:"local_port"`
-	AutoConnect bool   `yaml:"auto_connect,omitempty" mapstructure:"auto_connect"`
+	Name        string       `yaml:"name" mapstructure:"name"`
+	Description string       `yaml:"description" mapstructure:"description"`
+	Type        string       `yaml:"type,omitempty" mapstructure:"type"`
+	Target      TunnelTarget `yaml:"target,omitempty" mapstructure:"target"`
+	RemoteHost  string       `yaml:"remote_host" mapstructure:"remote_host"`
+	RemotePort  int          `yaml:"remote_port" mapstructure:"remote_port"`
+	LocalPort   int          `yaml:"local_port" mapstructure:"local_port"`
+	AutoConnect bool         `yaml:"auto_connect,omitempty" mapstructure:"auto_connect"`
 }
 
 // VPNType represents the type of VPN connection.


### PR DESCRIPTION
# feat(tunnel): CloudFormation target resolution for AWS SSM tunnels

## What

Extends the `target` field in AWS SSM tunnels to resolve the EC2 bastion instance ID dynamically
from **CloudFormation Exports** or **CloudFormation Stack Outputs**, in addition to the existing
literal string form.

Three forms are now accepted:

```yaml
tunnels:
  # 1. Literal EC2 instance ID (existing behaviour, unchanged)
  - name: redis
    type: aws
    target: i-0abc123def456789a
    remote_host: cache.internal.vpc
    remote_port: 6379
    local_port: 6379

  # 2. CloudFormation Export — resolved via aws cloudformation list-exports
  - name: postgres
    type: aws
    target:
      export: MyStack-BastionInstanceId
    remote_host: db.internal.vpc
    remote_port: 5432
    local_port: 5432
    auto_connect: true

  # 3. CloudFormation Stack Output — resolved via aws cloudformation describe-stacks
  - name: opensearch
    type: aws
    target:
      stack: myproject-prod-infra
      output: BastionInstanceId
    remote_host: opensearch.internal.vpc
    remote_port: 9200
    local_port: 9200
```

## Why

When infrastructure is managed by CloudFormation (or Terraform with CF outputs), the EC2 bastion
instance ID changes every time the stack is recreated. Hardcoding `i-xxxxxxxxxxxxxxxxx` in the
context YAML means updating it manually after every deployment.

CloudFormation Exports and Stack Outputs are stable named references that survive instance
replacements — ctx can resolve them automatically at tunnel start time.

## How it works

- `TunnelTarget` is now a polymorphic type implementing `yaml.Unmarshaler` / `yaml.Marshaler`:
  accepts a plain string (literal) or a mapping with `export` or `stack`+`output` keys; any
  other mapping shape sets `Kind: invalid`
- At tunnel start, `resolveAWSTarget` dispatches to `resolveCFExport` or `resolveCFStackOutput`
  depending on the kind
- `resolveCFExport` paginates through all CloudFormation exports using `NextToken` — accounts
  with many exports would otherwise silently miss the target on the first page
- Target validation (empty target, invalid format, `stack` without `output`) is enforced at
  tunnel start time with a `⚠ warn + skip` instead of blocking `ctx use` entirely — a config
  typo in one tunnel no longer prevents credentials or k8s context from being set
- The `output` field error message explicitly hints at the common `outputs` typo:
  `target.stack requires target.output (got empty — check for typos like 'outputs')`

## Requirements to test

Same as the base AWS tunnel feature (AWS CLI v2 + session-manager-plugin). For CF resolution:

```json
{
  "Effect": "Allow",
  "Action": [
    "cloudformation:ListExports",
    "cloudformation:DescribeStacks"
  ],
  "Resource": "*"
}
```

## Checklist

- [x] `go test ./...` — all passing (7 new tests for `resolveAWSTarget`/pagination, 4 new for `TunnelTarget` marshal/unmarshal, 3 updated in `context_test.go`)
- [x] `golangci-lint run` — no new warnings (4 pre-existing warnings in unrelated code)
- [x] `reuse lint` — compliant
- [x] `go build ./...` — clean
- [x] Docs updated: `docs/features/tunnels.md` (all three target forms + IAM permissions table)
- [x] Example added: `examples/aws-tunnel-cf-target.yaml`

## Files changed

| File | Change |
|------|--------|
| `internal/config/types_definitions.go` | Add `TunnelTarget` type with `UnmarshalYAML`/`MarshalYAML`; `TunnelConfig.Target` changes from `string` to `TunnelTarget` |
| `internal/config/context.go` | Remove hard validation of AWS target — moved to warn+skip at tunnel start |
| `internal/config/tunnel_target_test.go` | New file — table-driven tests for all `TunnelTarget` marshal/unmarshal paths |
| `internal/config/context_test.go` | 3 test cases updated: invalid targets now `wantErr: false` with descriptive names |
| `internal/cli/tunnel.go` | `validateTunnelTarget` + `resolveAWSTarget` + `resolveCFExport` (paginated) + `resolveCFStackOutput`; both `runTunnelUp` and `startAutoConnectTunnels` updated |
| `internal/cli/tunnel_ssm_test.go` | 7 new `resolveAWSTarget` tests including pagination; SPDX header corrected |
| `docs/features/tunnels.md` | Full documentation of all three `target` forms + IAM permissions |
| `examples/aws-tunnel-cf-target.yaml` | New example showing all three target forms |

---

<details>
<summary>Design notes</summary>

## Why polymorphic YAML and not separate fields

An alternative would have been three separate fields (`target_literal`, `target_export`,
`target_stack` + `target_output`). The polymorphic approach was chosen because:

- The YAML reads naturally — the same `target:` key regardless of form
- It is backward-compatible: existing configs with `target: i-xxx` continue to work unchanged
- It mirrors how tools like Helm and Kubernetes CRDs handle this pattern

## Pagination correctness

`json.Unmarshal` only sets struct fields present in the JSON — it does not zero-reset absent
fields. If the result struct is declared outside the loop, `NextToken` from page N persists into
page N+1's parse even when the last page has no `NextToken` key, producing an infinite loop.
The fix is to declare `var result struct{...}` inside the loop body so it zero-initialises on
each iteration.

## Graceful degradation

The original implementation validated `target` inside `ValidateContext`, which is called early in
`ctx use`. A misconfigured target (e.g. the `outputs` vs `output` typo) would abort the entire
context switch — blocking credentials, k8s context, and everything else.

The validation was moved to `validateTunnelTarget`, called inside the tunnel start loops. Invalid
tunnels emit a `⚠` warning and are skipped; everything else proceeds normally.

</details>

---

## A note on transparency

This PR extends the AWS SSM tunnel feature contributed in #23. Like that PR, it was built with
the assistance of [Claude Code](https://claude.com/claude-code). The use case, design decisions,
and functional testing against a real AWS environment are mine — the `outputs` typo that motivated
the graceful degradation fix was a real mistake I hit while configuring my own context.